### PR TITLE
Fix adaptive layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vcs-game-maker",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@
       height="72"
     >
       <v-spacer></v-spacer>
+      Insert here!
 
       <v-responsive max-width="156">
         <v-text-field

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,18 +16,17 @@
       flat
       height="72"
     >
-      <v-spacer></v-spacer>
-      Insert here!
-
-      <v-responsive max-width="156">
-        <v-text-field
-          dense
-          flat
-          hide-details
-          rounded
-          solo-inverted
-        ></v-text-field>
-      </v-responsive>
+      <v-toolbar
+        flat
+        class="navigation-list"
+      >
+        <v-btn to="/" link class="actions-item" title="Actions">
+          <v-icon>mdi-chart-scatter-plot</v-icon>
+        </v-btn>
+        <v-btn to="/player0" link class="player0-item" title="Player 0">
+          <v-icon>mdi-human-handsup</v-icon>
+        </v-btn>
+      </v-toolbar>
     </v-app-bar>
 
     <v-navigation-drawer

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,11 +20,32 @@
         flat
         class="navigation-list"
       >
-        <v-btn to="/" link class="actions-item" title="Actions">
+        <v-btn to="/" link class="actions-item" title="Actions" elevation="0">
           <v-icon>mdi-chart-scatter-plot</v-icon>
         </v-btn>
-        <v-btn to="/player0" link class="player0-item" title="Player 0">
+
+        <v-btn to="/player0" link class="player0-item" title="Player 0" elevation="0">
           <v-icon>mdi-human-handsup</v-icon>
+        </v-btn>
+
+        <v-btn to="/player1" link class="player1-item" title="Player 1" elevation="0">
+          <v-icon>mdi-human-handsup</v-icon>
+        </v-btn>
+
+        <v-btn to="/background" link class="background-item" title="Background" elevation="0">
+          <v-icon>mdi-map</v-icon>
+        </v-btn>
+
+        <v-btn to="/sound" link class="sound-item" title="Sound" elevation="0">
+          <v-icon>mdi-speaker</v-icon>
+        </v-btn>
+
+        <v-btn to="/generated" link class="generated-item" title="Generated" elevation="0">
+          <v-icon>mdi-card-text</v-icon>
+        </v-btn>
+
+        <v-btn to="/project" link class="project-item" title="Project" elevation="0">
+          <v-icon>mdi-pencil-ruler</v-icon>
         </v-btn>
       </v-toolbar>
     </v-app-bar>

--- a/src/App.vue
+++ b/src/App.vue
@@ -163,6 +163,7 @@
       app
       clipped
       right
+      permanent
     >
       <div id="javatari-target-container"></div>
       <v-btn block color="primary" @click="handleRomDownload">


### PR DESCRIPTION
This version adds a toolbar at the top, so that, even if running on a narrow window, the user will still be able to navigate between the various editors: