### PR TITLE
Fix bug where sprite edits where being lost

### DIFF
--- a/src/components/PixelEditor.vue
+++ b/src/components/PixelEditor.vue
@@ -195,7 +195,7 @@ export default {
         // eslint-disable-next-line no-invalid-this
         this.$emit('input', pixels);
       }
-    }, 300),
+    }, 10),
 
     handleExportImage() {
       // Adapted from https://stackoverflow.com/a/28305948/679240


### PR DESCRIPTION
The original error occurred because of the debounce: 
- If the player changed pages too quickly after making the edit, it failed to be stored;
- Fixed by reducing the debounce from 300 millis to 10 millis.