### PR TITLE
Fix animation frame overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vcs-game-maker",
-  "version": "0.47.3",
+  "version": "0.47.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/generators/bbasic.js
+++ b/src/generators/bbasic.js
@@ -469,7 +469,7 @@ Blockly.BBasic.generateAnimations = function() {
 
     return `  rem Animation ${animationIndex} ${animation.name} for ${name}:\n\n` +
       `  ${name}frame = ${name}frame + 1\n` +
-      `  if ${name}frame = ${totalDuration} then ${name}frame = 0\n\n` +
+      `  if ${name}frame >= ${totalDuration} then ${name}frame = 0\n\n` +
       stateMachine.join('\n\n') +
       `\n\n${animationLabel}animationEnd`;
   };


### PR DESCRIPTION
Player animations didn't properly reset to first frame when switching between animations.

The variables that controlled the animation frame weren't properly resetting.