### PR TITLE
Fix ball-width CTRLPF bug, dialog/emulator-drawer z-index, envelope graph polish, Sound FX/Text column layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vcs-game-maker",
   "productName": "VCS Game Maker",
-  "version": "0.50.24",
+  "version": "0.50.25",
   "private": true,
   "description": "A no-code environment for creating Atari 2600 games using Blockly and batari Basic.",
   "author": "haroldo-ok, with contributions by AbstractPolygon",

--- a/src/App.vue
+++ b/src/App.vue
@@ -243,6 +243,7 @@
       right
       class="emulator-drawer"
       :width="emulatorWidth"
+      :mobile-breakpoint="0"
     >
       <div class="emulator-drawer-inner" :style="{paddingBottom: errorHeight + 'px'}">
         <v-btn
@@ -1046,9 +1047,27 @@ export default {
    confirmation) instead of under them. Pushed well above every one of
    those instead of tuning each one down, so no future chrome-level z-index
    added here needs to keep this in mind too. */
+/* Was pinned to a fixed 30 - too low. .v-overlay (Vuetify's own generic
+   modal-backdrop wrapper - shared by v-dialog, v-menu, AND a temporary
+   v-navigation-drawer's own scrim, e.g. the emulator sidebar) gets its own
+   z-index assigned dynamically by Vuetify, unrelated to this stylesheet,
+   and it climbs over a long session as more menus/dialogs open - confirmed
+   directly, it drifted to 201, well above this fixed 30, putting a
+   dialog's own scrim on top of its content and making the dialog's buttons
+   unclickable (document.elementFromPoint() at their center returned the
+   scrim, not the button - reported as "Create New Project" doing nothing
+   when clicked).
+   An earlier fix for this pinned .v-overlay itself below 30 instead of
+   raising this - wrong, since .v-overlay isn't dialog-specific: capping it
+   also capped the emulator sidebar's own drawer scrim, breaking ITS
+   stacking (reported directly: "the emulator sidebar is now behind the
+   overlay"). Raised high enough here instead that it stays above .v-overlay
+   regardless of how far that drifts, without touching .v-overlay at all -
+   the fix stays scoped to dialogs/menus, the only things that were ever
+   actually broken. */
 .v-menu__content,
 .v-dialog__content {
-  z-index: 30 !important;
+  z-index: 300 !important;
 }
 
 * {
@@ -1215,6 +1234,68 @@ html {
 [class*="-renderer"][class*="-theme"] .blocklyText,
 [class*="-renderer"][class*="-theme"] .blocklyFlyoutLabelText {
   font-family: var(--blockly-font-family) !important;
+}
+
+/* The color picker (field_grid_dropdown, see blocks/color.js's own
+   color_get) - white background + rounded corners instead of Blockly's own
+   default (the block's own colour, purple here, tinting the whole flyout -
+   set directly as an inline style by DropDownDiv.setColour(), hence
+   !important to win over it). :has(.fieldGridDropDownContainer) scopes this
+   to only the grid-dropdown color picker specifically - .blocklyDropDownDiv
+   is a single shared singleton every ordinary (non-grid) dropdown field
+   also reuses, so a blanket override here would have re-colored every
+   plain dropdown's own flyout too. */
+.blocklyDropDownDiv:has(.fieldGridDropDownContainer) {
+  background-color: #fff !important;
+  border-radius: 8px !important;
+}
+
+/* @blockly/field-grid-dropdown's own default 7px grid-gap between cells -
+   with the border/padding shrink below already making each cell mostly
+   just its own swatch, that gap read as a wide, oddly deliberate-looking
+   gutter between adjacent colors rather than the label-affording spacing
+   it was originally sized for. */
+.fieldGridDropDownContainer.blocklyMenu {
+  grid-gap: 0 !important;
+}
+
+/* Each swatch cell's own bordered frame, shrunk to match blocks/color.js's
+   own 28x28 swatch images (up from an original 16x16) - @blockly/field-
+   grid-dropdown's own default padding-left:15px is leftover checkmark
+   space (this app already hides the checkmark itself, see that package's
+   own CSS), which otherwise left every swatch floating off-center in a
+   much bigger, mostly-empty cell instead of filling it. That same package's
+   own default 1px dark border around every cell is dropped too (border:
+   none) - once the swatch itself fills the whole cell (padding above), that
+   border just drew a visible dark line on top of/around the color square
+   rather than framing empty space the way it did before. */
+.fieldGridDropDownContainer.blocklyMenu .blocklyMenuItem {
+  padding: 4px !important;
+  border: none !important;
+}
+
+/* The swatch <img> itself is a default INLINE element, which (like any
+   inline element) reserves descender space below its own baseline within
+   its containing block - confirmed directly by measuring the two rects:
+   the image sat flush against its own cell's top with the entire gap
+   sitting underneath it, exactly the classic "inline image leaves a sliver
+   of empty space below it" quirk, not a padding/centering issue. display:
+   block removes it from the inline flow entirely, closing that gap. */
+.fieldGridDropDownContainer.blocklyMenu .blocklyMenuItem img {
+  display: block !important;
+}
+
+/* The currently-selected swatch (whichever color this field is already set
+   to) - @blockly/field-grid-dropdown's own default is a translucent dark
+   overlay wash across the whole cell (background-color: rgba(1,1,1,.25)),
+   muddying the actual color underneath rather than clearly marking it as
+   selected. A 2px solid black INSET box-shadow instead - inset (not a
+   plain border) so it draws inside the cell's existing bounds rather than
+   adding to them, which would otherwise shift/shrink the swatch image
+   relative to every other (unselected) cell's own size. */
+.fieldGridDropDownContainer.blocklyMenu .blocklyMenuItemSelected {
+  background-color: transparent !important;
+  box-shadow: inset 0 0 0 2px #000 !important;
 }
 
 /* Vuetify's own hint/error text under a field (e.g. the description under

--- a/src/blocks/collision.js
+++ b/src/blocks/collision.js
@@ -86,3 +86,13 @@ const buildCollisionCheckBlock = () => ({
 Blockly.defineBlocksWithJsonArray([
   buildCollisionCheckBlock(),
 ]);
+
+// Software (pfread-based) playfield collision for players - taken out again
+// for now, on top of the two designs already documented above/in
+// generators/bbasic/collision.js's own top-of-file comment (a reactive
+// axis-aware backtrack: ROM lockup, then a hard crash on contact; a
+// predictive per-direction "move if clear" block, closely modeled on the
+// user's own reference example: moved correctly but caused a screen roll on
+// any joystick input, still unresolved). Revisit later - see git history on
+// this file and on generators/bbasic/collision.js for the full account of
+// every attempt so far before trying again.

--- a/src/blocks/color.js
+++ b/src/blocks/color.js
@@ -4,10 +4,16 @@ import '@blockly/field-grid-dropdown';
 import {COLOR_ICON} from './icon';
 import {NTSC_COLORS} from '../utils/palette';
 
+// 28x28 (up from an original 16x16) - see App.vue's own global .blocklyMenuItem
+// padding override, which shrinks each grid cell's own frame to match: a
+// swatch this size fills its bordered cell edge to edge instead of floating
+// as a small square inside a much bigger padded frame.
+const SWATCH_SIZE = 28;
+
 const colorToDataURL = (color) => {
   const canvas = window.document.createElement('canvas');
-  canvas.width = 16;
-  canvas.height = 16;
+  canvas.width = SWATCH_SIZE;
+  canvas.height = SWATCH_SIZE;
 
   const ctx = canvas.getContext('2d');
   ctx.fillStyle = color;
@@ -23,8 +29,8 @@ const colorToDataURL = (color) => {
 export const NTSC_COLOR_OPTIONS = NTSC_COLORS.map((color, idx) => ([
   {
     src: colorToDataURL(`#${color}`),
-    width: 16,
-    height: 16,
+    width: SWATCH_SIZE,
+    height: SWATCH_SIZE,
   },
   `${idx << 1}`,
 ]));

--- a/src/components/ActionEditor.vue
+++ b/src/components/ActionEditor.vue
@@ -48,7 +48,7 @@ import blocklyToolboxExampleEvent from 'raw-loader!./blockly-toolbox-example-eve
 import BlocklyBB from '../generators/bbasic';
 import {showError} from '../utils/build-error';
 import {useWorkspaceStorage, useErrorStorage, useConfigurationStorage, useMuteBlocklySoundsStorage,
-  useGridSnapStorage} from '../hooks/project';
+  useGridSnapStorage, useDesaturateBlocklyColorsStorage} from '../hooks/project';
 import {useGeneratedBasic} from '../hooks/generated';
 import {markRomOutdated} from '../hooks/rom';
 
@@ -119,6 +119,21 @@ export default {
     const configurationStorage = useConfigurationStorage();
     const muteBlocklySoundsStorage = useMuteBlocklySoundsStorage();
     const gridSnapStorage = useGridSnapStorage();
+    // A plain one-off .value read (not a reactive binding) - same "only
+    // takes effect on the next remount" reasoning as gridSnapStorage.value
+    // just below (options.grid.snap): Blockly.inject() only ever reads
+    // options.theme once, at injection time, so a live binding here
+    // wouldn't do anything useful anyway - toggling this setting already
+    // requires leaving and revisiting the Actions tab for the renderer/
+    // theme-level effects it has elsewhere (see ActionEditor.vue's own
+    // renderer comment). Mutates APP_BLOCKLY_THEME itself (a module-level
+    // singleton reused by every mount) via setComponentStyle - the theme
+    // object is otherwise defined once, at import time, well before any
+    // component (and so this storage value) could ever be read, so there's
+    // no other point BEFORE injection where this could be set instead.
+    const desaturateBlocklyColors = useDesaturateBlocklyColorsStorage().value;
+    APP_BLOCKLY_THEME.setComponentStyle('workspaceBackgroundColour',
+        desaturateBlocklyColors ? '#e8e8e8' : null);
     return {
       generatedBasic: useGeneratedBasic(),
       muteBlocklySoundsStorage,
@@ -140,7 +155,11 @@ export default {
         grid: {
           spacing: 25,
           length: 3,
-          colour: '#ccc',
+          // A touch darker than the usual '#ccc' once the workspace
+          // background itself is dimmed (see desaturateBlocklyColors
+          // above) - '#ccc' dots read fine against pure white, but lose
+          // enough contrast against '#e8e8e8' to be hard to see.
+          colour: desaturateBlocklyColors ? '#bbb' : '#ccc',
           // Blockly.inject() only ever reads this once, at injection time
           // (see toggleGridSnap's own comment on Grid.prototype.shouldSnap
           // having no supported setter) - seeding it from the persisted

--- a/src/components/BlocklyComponent.vue
+++ b/src/components/BlocklyComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="blocklyDiv" ref="blocklyDiv">
+    <div class="blocklyDiv" :class="{'blocklyDiv-desaturated': desaturateBlocklyColors}" ref="blocklyDiv">
     </div>
     <xml ref="blocklyToolbox" style="display:none">
       <slot></slot>
@@ -35,7 +35,7 @@
 import Blockly from 'blockly';
 import {debounce} from 'lodash';
 
-import {useBlocklyControlsHorizontalStorage} from '../hooks/project';
+import {useBlocklyControlsHorizontalStorage, useDesaturateBlocklyColorsStorage} from '../hooks/project';
 
 // Blockly's own default for a block style's colourTertiary (the outline/
 // border stroke colour - see renderers/common/path_object.js's own
@@ -58,6 +58,151 @@ import {useBlocklyControlsHorizontalStorage} from '../hooks/project';
 Blockly.blockRendering.ConstantProvider.prototype.generateTertiaryColour_ = function(colour) {
   return Blockly.utils.colour.blend('#000', colour, 0.3) || colour;
 };
+
+// Options tab's own "Desaturate Blockly block colors" toggle (see
+// useDesaturateBlocklyColorsStorage in hooks/project.js) - -50% saturation,
+// applied in real HSL space (matching Photoshop's own Hue/Saturation
+// adjustment, which scales S the same way) - NOT a CSS filter:
+// filter: saturate() operates on non-linear sRGB via a fixed luminance
+// matrix, a different algorithm that visibly darkened blues in particular
+// instead of just muting them, confirmed as a real reported mismatch
+// against Photoshop's own result at the same "50%".
+const clamp01 = (n) => Math.max(0, Math.min(1, n));
+
+const hexToRgb = (hex) => {
+  const clean = hex.replace('#', '');
+  return [0, 2, 4].map((i) => parseInt(clean.substr(i, 2), 16) / 255);
+};
+
+const rgbToHex = (r, g, b) => '#' + [r, g, b]
+    .map((v) => Math.round(clamp01(v) * 255).toString(16).padStart(2, '0'))
+    .join('');
+
+// Standard RGB<->HSL conversion (e.g. matching the CSS Color 4 spec's own
+// algorithm) - h in [0,1) (not degrees), s/l in [0,1].
+const rgbToHsl = (r, g, b) => {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return [0, 0, l];
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h;
+  if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  return [h / 6, s, l];
+};
+
+const hue2rgb = (p, q, tIn) => {
+  let t = tIn;
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+};
+
+const hslToRgb = (h, s, l) => {
+  if (s === 0) return [l, l, l];
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return [hue2rgb(p, q, h + 1 / 3), hue2rgb(p, q, h), hue2rgb(p, q, h - 1 / 3)];
+};
+
+// saturationFactor multiplies S (0.5 = Photoshop's "-50") - same slider
+// Photoshop's own Hue/Saturation dialog exposes, applied to the same
+// component.
+const desaturateHex = (hex, saturationFactor) => {
+  const [h, s, l] = rgbToHsl(...hexToRgb(hex));
+  const [r, g, b] = hslToRgb(h, clamp01(s * saturationFactor), l);
+  return rgbToHex(r, g, b);
+};
+
+// Blockly.utils.parseBlockColour is the single funnel every block's own
+// colour - a Classic-theme hue NUMBER (see generateTertiaryColour_'s own
+// comment above) or a raw hex/CSS colour name string alike - resolves
+// through on its way to becoming colourPrimary (see renderers/common/
+// constants.js's own validatedBlockStyle_), so patching THIS one function
+// covers every block regardless of which of those two forms defined its
+// colour, with no per-block-file changes needed - and colourSecondary/
+// colourTertiary (generateSecondaryColour_/generateTertiaryColour_ above)
+// both derive FROM colourPrimary, so they pick up the same desaturated
+// base automatically too, with no separate patch of their own required.
+// Read live (not cached) on every call, same "just check the stored value
+// directly, no reactive binding needed" pattern isBlocklyControlsHorizontal
+// below already uses - this only ever actually runs while a workspace is
+// being (re)injected, once per tab visit, so there's no live-toggle-
+// mid-session case to handle here.
+//
+// Guarded (isDesaturationPatch) against re-wrapping itself - the 'blockly'
+// module instance persists across this FILE's own dev-server hot-reloads,
+// but this file's own module-level code (this patch included) re-executes
+// on every one of them; without the guard, each edit-triggered reload
+// wrapped whatever the PREVIOUS reload had already wrapped, compounding the
+// desaturation further with every single edit made during a dev session -
+// confirmed as the actual cause of a real reported "the colors just
+// changed, they looked right and now don't" mid-session, with no code
+// change of the actual 0.5 factor involved at all.
+if (!Blockly.utils.parseBlockColour.isDesaturationPatch) {
+  const originalParseBlockColour = Blockly.utils.parseBlockColour;
+  Blockly.utils.parseBlockColour = function(colour) {
+    const result = originalParseBlockColour.call(this, colour);
+    if (useDesaturateBlocklyColorsStorage().value) {
+      result.hex = desaturateHex(result.hex, 0.5);
+    }
+    return result;
+  };
+  Blockly.utils.parseBlockColour.isDesaturationPatch = true;
+}
+
+// Same reasoning/guard as the parseBlockColour patch just above, for the
+// TOOLBOX CATEGORY labels ("Logic", "Loops", "Math", etc) - confirmed
+// directly that these resolve their own colour through an entirely
+// SEPARATE function (ToolboxCategory.prototype.parseColour_, not
+// Blockly.utils.parseBlockColour), so without this, "Soft Blockly colors"
+// left every category label in the toolbox sidebar still fully saturated
+// even with every actual block already muted.
+if (!Blockly.ToolboxCategory.prototype.parseColour_.isDesaturationPatch) {
+  const originalParseColour = Blockly.ToolboxCategory.prototype.parseColour_;
+  Blockly.ToolboxCategory.prototype.parseColour_ = function(colourValue) {
+    const hex = originalParseColour.call(this, colourValue);
+    return hex && useDesaturateBlocklyColorsStorage().value ? desaturateHex(hex, 0.5) : hex;
+  };
+  Blockly.ToolboxCategory.prototype.parseColour_.isDesaturationPatch = true;
+}
+
+// Keeps the toolbox flyout (the drawer of draggable block previews a
+// clicked category opens) open across a zoom - confirmed directly that
+// WorkspaceSvg.prototype.setScale (the function EVERY zoom path - the +/-
+// buttons, Ctrl+wheel, zoom-to-fit, zoom-reset - ultimately calls)
+// unconditionally calls Blockly.hideChaff(false) itself, and that false
+// (not true - see hideChaff's own "onlyClosePopups" parameter) is
+// specifically what tells the flyout to close itself, not just dismiss
+// unrelated popups like tooltips/context menus. A real reported
+// annoyance: picking a category, then zooming to get a better look before
+// dragging a block in, closed the very drawer you were about to drag from.
+//
+// Temporarily swaps out Blockly.hideChaff for the duration of setScale's
+// own (synchronous) call, forcing it to behave as if onlyClosePopups were
+// always true - deliberately NOT a permanent override of hideChaff
+// itself, which would also leave the flyout open on every OTHER
+// hideChaff(false) call site too (e.g. clicking empty canvas), well
+// beyond what was actually asked for ("when zooming").
+if (!Blockly.WorkspaceSvg.prototype.setScale.isKeepFlyoutOpenPatch) {
+  const originalSetScale = Blockly.WorkspaceSvg.prototype.setScale;
+  Blockly.WorkspaceSvg.prototype.setScale = function(newScale) {
+    const originalHideChaff = Blockly.hideChaff;
+    Blockly.hideChaff = () => originalHideChaff(true);
+    try {
+      originalSetScale.call(this, newScale);
+    } finally {
+      Blockly.hideChaff = originalHideChaff;
+    }
+  };
+  Blockly.WorkspaceSvg.prototype.setScale.isKeepFlyoutOpenPatch = true;
+}
 
 // Deliberately thinner than App.vue's global ::-webkit-scrollbar (16px) -
 // the Blockly canvas is dense with blocks, so a scrollbar that size reads as
@@ -356,6 +501,15 @@ Blockly.BlockSvg.prototype.moveDuringDrag = function(newLoc) {
 // fix) - once that's on, stock Blockly's own logic already does exactly
 // what's wanted with no override needed.
 
+// Module-scope (not component data) - same reasoning as every other
+// "survive remount" ref elsewhere in this app (e.g. BackgroundEditor.vue's
+// own copiedBackgroundData): Vue Router destroys and recreates this
+// component every time its tab is left and revisited, so a plain instance
+// property would reset right back to nothing on every visit. Only ever
+// read/written imperatively (see mounted()/beforeDestroy() below), never
+// bound in a template, so a plain object is enough - no reactivity needed.
+let savedScrollState = null;
+
 export default {
   name: 'BlocklyComponent',
   props: ['options', 'value'],
@@ -364,6 +518,18 @@ export default {
       workspace: null,
       lastSavedWorkspace: null,
     };
+  },
+  computed: {
+    // Only the block TEXT (see .blocklyDiv-desaturated's own CSS comment
+    // for why emoji glyphs specifically need this, unlike ordinary block
+    // fill colours - see Blockly.utils.parseBlockColour's own patch above)
+    // needs a live, reactive binding here - block fill colour itself is
+    // desaturated once, up front, at colour-resolution time, with no
+    // per-render reactivity needed since a workspace is never re-injected
+    // without a full remount anyway.
+    desaturateBlocklyColors() {
+      return useDesaturateBlocklyColorsStorage().value;
+    },
   },
   mounted() {
     const options = this.$props.options || {};
@@ -374,6 +540,46 @@ export default {
     this.workspace = Blockly.inject(this.$refs['blocklyDiv'], options);
     this.workspace.addChangeListener(debounce(() => this.handleChange()));
     this.loadWorkspace(this.value);
+
+    // IBM Plex Mono (--blockly-font-family, see App.vue) loads asynchronously
+    // via a <link> in public/index.html, same as any web font - if it's
+    // still downloading when Blockly.inject() above first measures every
+    // block's own text to size its shape, blocks get sized against the
+    // fallback ("monospace") font's metrics instead. The font then swaps in
+    // visually once it finishes loading, but Blockly never re-measures
+    // existing blocks on its own, so they stay the WRONG size (sized for the
+    // fallback font, now showing the real font's glyphs) until something
+    // forces a re-render - confirmed as a real reported bug ("blocks aren't
+    // sized correctly when first created, a page refresh fixes it" - refresh
+    // just means the font is already cached the second time, so this race
+    // never happens then). document.fonts.ready resolves once every font
+    // requested so far has actually finished loading (immediately, if none
+    // were still pending) - re-rendering every block at that point re-runs
+    // Blockly's own text measurement against the NOW-correct font, fixing
+    // the sizing without needing a manual refresh.
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(() => {
+        if (!this.workspace) return;
+        this.workspace.getAllBlocks(false).forEach((block) => block.render());
+      });
+    }
+
+    // Applied synchronously, right here - BEFORE the browser ever paints
+    // this mount's own first frame - rather than from inside the resize-
+    // settle pass below. An earlier version restored it there instead
+    // (reasoning: scroll(x, y) is a raw pixel translate, not something that
+    // depends on the container's own size the way the scrollbar's THUMB
+    // position does - see resizeWorkspace's own comment just below for the
+    // actual thing that settle pass exists for), which was confirmed as a
+    // real, reported bug: the workspace visibly rendered at Blockly's own
+    // default scroll position for a moment, then visibly JUMPED to the
+    // saved one about 100ms later. Restoring it here instead means this
+    // mount's very first paint already shows the right place - no jump to
+    // see at all.
+    if (savedScrollState) {
+      this.workspace.setScale(savedScrollState.scale);
+      this.workspace.scroll(savedScrollState.scrollX, savedScrollState.scrollY);
+    }
 
     // Keep the Blockly SVG sized to its container. The surrounding layout can
     // resize the container after inject (Blockly only reflows on window
@@ -401,6 +607,17 @@ export default {
     this.resizeObserver.observe(this.$refs['blocklyDiv']);
   },
   beforeDestroy() {
+    // Captured here (not just read live from this.workspace whenever
+    // mounted() next needs it) since the workspace itself - along with
+    // scrollX/scrollY/scale - is torn down entirely once this component is
+    // destroyed; this is the last point they're still readable.
+    if (this.workspace) {
+      savedScrollState = {
+        scrollX: this.workspace.scrollX,
+        scrollY: this.workspace.scrollY,
+        scale: this.workspace.scale,
+      };
+    }
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
@@ -458,5 +675,29 @@ export default {
   height: 100%;
   width: 100%;
   text-align: left;
+}
+
+/* Options tab's own "Desaturate Blockly block colors" toggle, the text/
+   emoji half - see Blockly.utils.parseBlockColour's own patch above for
+   the block FILL colour half. Emoji icon characters embedded in a block's
+   own message string (see blocks/icon.js - MISSILE_ICON, COLOR_ICON, etc)
+   render as native colour-emoji glyphs via the OS/browser's own emoji
+   font, entirely outside Blockly's SVG fill/theme system - there's no
+   "colour" value to desaturate in HSL the way a block's own fill has, so
+   this is a plain CSS filter instead, scoped to just the text elements
+   (same .blocklyText/.blocklyFlyoutLabelText classes App.vue's own font-
+   family override already targets, for the same "block canvas AND
+   toolbox/flyout both" reach) rather than the whole canvas - a filter
+   across the ENTIRE .blocklyDiv was tried first and reverted (see this
+   component's own git history): saturate() uses a different algorithm
+   than Photoshop's HSL-based slider (see parseBlockColour's own comment),
+   and applying it to block fills a SECOND time on top of the already-
+   desaturated HSL fills double-muted them. >>> pierces this component's
+   own scoped CSS boundary - Blockly injects its SVG text nodes into
+   .blocklyDiv at runtime, so they never carry this component's own scope
+   attribute the way template-authored elements do. */
+.blocklyDiv-desaturated >>> .blocklyText,
+.blocklyDiv-desaturated >>> .blocklyFlyoutLabelText {
+  filter: saturate(50%);
 }
 </style>

--- a/src/components/EnvelopeGraph.vue
+++ b/src/components/EnvelopeGraph.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="envelope-graph-wrapper">
-    <div class="envelope-graph-scale">
-      <span
-        v-for="tick in scaleTicks"
-        v-bind:key="tick"
-        class="envelope-graph-scale-tick"
-        :style="{top: (100 - tick) + '%'}"
-      >{{ tick }}</span>
-    </div>
     <div class="envelope-graph" ref="container">
+      <div class="envelope-graph-scale">
+        <span
+          v-for="tick in scaleTicks"
+          v-bind:key="tick"
+          class="envelope-graph-scale-tick"
+          :style="{top: (100 - tick) + '%'}"
+        >{{ tick }}</span>
+      </div>
       <!-- Exactly two kinds of vertical line: one at each user-editable
            dot's own CURRENT position (attack/decay/release-start - the
            three draggable handles below), and one above each stage
@@ -52,7 +52,7 @@
       <div
         class="envelope-graph-dot envelope-graph-dot-handle"
         :style="dotStyle(sustainEndX, sustainPercent)"
-        title="Release - drag to change how many frames it takes to reach silence"
+        title="Release/Sustain - drag horizontally to change Release, vertically to change Sustain level"
         @mousedown="startDrag('release', $event)"
       />
       <!-- Always sits at the graph's own right edge (releaseX is 100% by
@@ -226,7 +226,9 @@ export default defineComponent({
         // it, same self-correcting approximation decaySustain's own drag
         // already relies on).
         const release = this.snapTo(ENVELOPE_ATTACK_RELEASE_FRAME_OPTIONS, Math.max(0, totalUnits - xUnits));
+        const sustainPercent = this.snapTo(ENVELOPE_SUSTAIN_PERCENT_OPTIONS, yPercent);
         this.$emit('update:release', release);
+        this.$emit('update:sustainPercent', sustainPercent);
       }
     },
     stopDrag() {
@@ -246,7 +248,7 @@ export default defineComponent({
   display: flex;
   width: 100%;
   gap: 4px;
-  margin-top: 8px;
+  margin-top: 4px;
   /* Breathing room from whatever follows (e.g. SoundFXEditor.vue's own
      Delete button row, which sits flush with zero top padding) - without
      this the graph's own bottom edge and the next control below it touch
@@ -258,25 +260,44 @@ export default defineComponent({
 /* 0-100%, not a raw AUDV value - Sustain (and so this whole graph) is
    always a percentage of this preset's own peak volume, matching how
    ENVELOPE_SUSTAIN_PERCENT_OPTIONS itself is defined (see blocks/
-   soundfx.js). Right-aligned digits. Each tick is absolutely positioned
-   (see envelope-graph-scale-tick below) rather than flex "space-between" -
-   a plain span's own ~22px line-height meant 5 of them (110px) didn't fit
+   soundfx.js). Sits INSIDE the graph now, just past the left border,
+   overlaid on the curve/grid rather than its own separate column outside
+   the frame - each tick is absolutely positioned (see
+   envelope-graph-scale-tick below) rather than flex "space-between" - a
+   plain span's own ~22px line-height meant 5 of them (110px) didn't fit
    this 90px-tall column, so "space-between" silently grew the container
    and pushed every tick below "100" progressively lower than its real
    gridline. */
 .envelope-graph-scale {
-  position: relative;
-  font-size: 10px;
-  opacity: 0.6;
-  text-align: right;
-  /* Matches .envelope-graph's own height below, so each tick's own "top"
-     percent (0-100) lines up with that graph's identical 0-100% gridlines. */
+  position: absolute;
+  left: 6px;
+  top: 0;
+  /* Explicit height (matching .envelope-graph's own) rather than the
+     top:0/bottom:0 stretch trick other absolutely-positioned children here
+     use - this element's own text content gives it an intrinsic height
+     that top:0/bottom:0 alone doesn't override, which was making its
+     ticks' own percentage "top" values resolve against the wrong (much
+     taller) containing block. */
   height: 90px;
+  width: 20px;
+  font-size: 10px;
+  text-align: left;
+  pointer-events: none;
 }
 
 .envelope-graph-scale-tick {
   position: absolute;
-  right: 0;
+  left: 0;
+  /* Same flat grey as the x-axis stage labels (see
+     .envelope-graph-stage-label below) - a real color, not opacity, so it
+     doesn't also dilute the white outline below. */
+  color: #666;
+  /* Crisp 1px white outline at full opacity - -webkit-text-stroke draws a
+     real stroke (paint-order puts it BEHIND the fill) rather than the
+     softer, easy-to-miss-at-10px look stacked text-shadows gave at this
+     font size. */
+  -webkit-text-stroke: 3px #fff;
+  paint-order: stroke fill;
   transform: translateY(-50%);
 }
 
@@ -306,6 +327,13 @@ export default defineComponent({
   width: 100%;
   height: 100%;
   display: block;
+  /* Positioned (not just static/in-flow) so its own stacking is decided by
+     DOM order against .envelope-graph-scale, same as every other
+     absolutely-positioned sibling here - without this, a static element
+     always paints BELOW any positioned sibling regardless of source order,
+     which was putting the curve behind the y-axis text even after removing
+     that text's own z-index. */
+  position: relative;
 }
 
 .envelope-graph-snap-line-vertical {
@@ -377,7 +405,10 @@ export default defineComponent({
   transform: translateX(-50%);
   margin-top: 2px;
   font-size: 11px;
-  opacity: 0.6;
+  /* Flat grey (was opacity: 0.6) - same visual result, but a real color
+     the y-axis ticks can match exactly (see .envelope-graph-scale-tick's
+     own comment for why they use color instead of opacity). */
+  color: #666;
   white-space: nowrap;
 }
 </style>

--- a/src/generators/bbasic.bb.hbs
+++ b/src/generators/bbasic.bb.hbs
@@ -38,6 +38,7 @@
  player0animation = 1
 {{{ generatedTextMinikernelDefaults }}}
 {{{ generatedKeypadSetup }}}
+{{{ generatedCtrlpfShadowSetup }}}
 
 {{{ systemStartEvent }}}
 

--- a/src/generators/bbasic.js
+++ b/src/generators/bbasic.js
@@ -591,18 +591,25 @@ Blockly.BBasic.init = function(workspace) {
   this.projectMusic = resolveProjectMusic(workspace, this.notePlayedInstruments);
 
   // Whether channnel0duration/channnel1duration (see SYSTEM_VARIABLES'
-  // own comment) are needed at all - a "Play sound" block is the only thing
-  // that ever WRITES them (see soundfx.js's own soundfx_play generator), but
-  // music's own generated code READS them unconditionally too, whenever
-  // music exists at all (see generators/bbasic/music.js's own comments on
-  // "soundfx_play/channnel0duration+channnel1duration" - a sound effect
-  // sharing a channel with music needs to keep exclusive hardware control
-  // for its own duration), so either one alone already needs both vars to
-  // exist. A project with neither pays nothing - see
+  // own comment) are needed at all - two block types ever WRITE them:
+  // soundfx_play (see soundfx.js's own generator, a Sound-tab-preset
+  // reference) and simple_sound_set (see generators/bbasic/sound.js's own
+  // generator, the freeform "Play sound" block that sets AUDC/AUDF/AUDV
+  // directly) - confirmed as a real bug: simple_sound_set was missing here,
+  // so a project using ONLY that block (no soundfx_play, no music) never
+  // got channnel0duration/channnel1duration reserved/dim'd at all, and the
+  // generator's own reference to it fell through to DASM as a bare unknown
+  // symbol ("Unknown Mnemonic 'sta channnel0duration'"). Music's own
+  // generated code READS them unconditionally too, whenever music exists at
+  // all (see generators/bbasic/music.js's own comments on "soundfx_play/
+  // channnel0duration+channnel1duration" - a sound effect sharing a channel
+  // with music needs to keep exclusive hardware control for its own
+  // duration), so any one of the three alone already needs both vars to
+  // exist. A project using none of them pays nothing - see
   // generateChannelDurationChecks below, which reuses this same flag to
   // skip the per-frame decrement entirely, not just the dev vars.
   this.channelDurationUsed = !!this.projectMusic || workspace.getAllBlocks(false).some((block) =>
-    block.type === 'soundfx_play' && block.isEnabled());
+    (block.type === 'soundfx_play' || block.type === 'simple_sound_set') && block.isEnabled());
 
   // Every one-shot music event watch - "sequence chip finished"
   // (music_sequence_chip_finished/_by_id) AND "note played by instrument"

--- a/src/generators/bbasic.js
+++ b/src/generators/bbasic.js
@@ -36,7 +36,8 @@ import {scoreBkColorVarName} from './bbasic/score';
 import {processPlayerStorageDefaults, generateRomNoiseChecks, generateRainbowColorChecks,
   generateRainbowColorGraphics, rainbowColorNeedsPlayerColors, rainbowColorNeedsPlayer1Colors,
   reserveRomNoiseDevVars, reserveRainbowColorDevVars,
-  generateMissileFireChecks, reserveMissileFireDevVars} from './bbasic/sprites';
+  generateMissileFireChecks, reserveMissileFireDevVars,
+  reserveCtrlpfShadowDevVar, generateCtrlpfShadowSetup} from './bbasic/sprites';
 import {resolveProjectMusic, MUSIC_PLAY_RESET_NAME, MUSIC_PLAY_BY_ID_NAME,
   musicPlayByIdArgVarName, musicPlaySongResetName,
   registerMusicPlayResetSubroutine, resolveMusicEventFlags,
@@ -403,6 +404,28 @@ Blockly.BBasic.init = function(workspace) {
     }
   });
 
+  // Same early block-type pre-scan reasoning as above, for CTRLPF's own RAM
+  // shadow (see reserveCtrlpfShadowDevVar's own comment in generators/
+  // bbasic/sprites.js) - sprite_priority_set is its own dedicated block
+  // type, but ball width is just one VAR choice on the generic
+  // sprite_ball_set setter. VAR is a plain field_dropdown (see blocks/
+  // sprites.js's own buildSpriteBlocks), not a Blockly variable field, so
+  // its value IS the literal name string already ('ballwidth') - comparing
+  // it directly here, exactly like the generator's own `varName === 'ballwidth'`
+  // check does after resolving it through nameDB_. Two wrong approaches
+  // tried and ruled out first: workspace.getVariableById(fieldValue) always
+  // returned nothing (fieldValue was never a variable ID to begin with, so
+  // this pre-scan silently never found ball width in use); routing through
+  // this.nameDB_.getName(...) crashed instead, since nameDB_ isn't
+  // constructed yet this early in init() (it's set up further down, well
+  // after this pre-scan section runs).
+  this.ctrlpfShadowUsed = workspace.getAllBlocks(false).some((block) => {
+    if (!block.isEnabled()) return false;
+    if (block.type === 'sprite_priority_set') return true;
+    if (block.type === 'sprite_ball_set') return block.getFieldValue('VAR') === 'ballwidth';
+    return false;
+  });
+
   // Same early block-type pre-scan reasoning as the ones above - see
   // controls_repeat_ext's own comment in generators/bbasic/loops.js for
   // why a "repeat" block whose count is a complex expression needs its own
@@ -530,14 +553,16 @@ Blockly.BBasic.init = function(workspace) {
     this.distancePointChecks.set(block.id, {axis, obj0: block.getFieldValue('VAR0'), index: distancePointIndex, block});
   });
 
-  // Which players use the hardware-collision backtrack check block (see
+  // Which players use the hardware-collision backtrack block (see
   // blocks/collision.js) - each one needs its own pair of hidden bytes to
   // hold the position from before its last move, so this is decided before
   // variable letters are handed out below, same reason as the pre-scans
   // above.
   this.collisionMovePlayers = new Set();
   workspace.getAllBlocks(false).forEach((block) => {
-    if (block.type === 'collision_check_position') this.collisionMovePlayers.add(block.getFieldValue('PLAYER'));
+    if (block.type === 'collision_check_position') {
+      this.collisionMovePlayers.add(block.getFieldValue('PLAYER'));
+    }
   });
 
   // Every "fade finished" watch (background_fade_finished in blocks/
@@ -821,6 +846,12 @@ Blockly.BBasic.init = function(workspace) {
   // bbasic/sprites.js) - a no-op unless missileFireUsedFor's own early
   // pre-scan (above) found it used.
   reserveMissileFireDevVars(reserveDevVar, this.missileFireUsedFor);
+
+  // Same bucket again, for CTRLPF's own RAM shadow (see
+  // reserveCtrlpfShadowDevVar's own comment in generators/bbasic/sprites.js)
+  // - a no-op unless ctrlpfShadowUsed's own early pre-scan (above) found it
+  // used.
+  reserveCtrlpfShadowDevVar(reserveDevVar, this.ctrlpfShadowUsed);
 
   // Same bucket again, for "Joystick N direction (8-way)"'s own per-frame
   // result (see joyDir8ResultVarName's own comment in generators/bbasic/
@@ -1681,6 +1712,7 @@ Blockly.BBasic.finish = function(code) {
   const generatedRunOnceEdgeReset = Blockly.BBasic.generateRunOnceEdgeResetCall();
   const generatedKeypadPollCall = Blockly.BBasic.generateKeypadPollCall();
   const generatedKeypadSetup = Blockly.BBasic.generateKeypadSetup();
+  const generatedCtrlpfShadowSetup = generateCtrlpfShadowSetup(Blockly);
 
   this.isInitialized = false;
 
@@ -1711,7 +1743,7 @@ Blockly.BBasic.finish = function(code) {
     generatedBackgroundFadeChecks, generatedMusicChecks, generatedDistanceChecks, generatedDistancePointChecks,
     generatedJoystickDirection8Checks,
     generatedTextScrollAdvance, generatedScoreBkColorAsm, generatedRunOnceEdgeReset,
-    generatedKeypadPollCall, generatedKeypadSetup});
+    generatedKeypadPollCall, generatedKeypadSetup, generatedCtrlpfShadowSetup});
 };
 
 // Builds the run-once flag bytes' per-frame reset body - registered as the

--- a/src/generators/bbasic/collision.js
+++ b/src/generators/bbasic/collision.js
@@ -25,12 +25,16 @@ export const collisionMoveOldYVar = (playerNum) => `collisionOldY${playerNum}`;
 // fully reverted, after it caused two separate real bugs on an actual
 // project: a ROM lockup (an out-of-range playfield row index from the box
 // math, since fixed but apparently not the only issue) and, afterward, a
-// hard crash on contact that persisted even after that fix. Given this
-// exact class of collision code has now broken in more than one way across
-// more than one attempt (see the even earlier predictive, run-every-frame
+// hard crash on contact that persisted even after that fix. A further
+// predictive, per-direction "move if clear" version (checking before moving
+// instead of reverting after, closely modeled on a working reference
+// example) was also tried and reverted - it moved correctly, but caused a
+// screen roll on any joystick input, still unresolved. Given this exact
+// class of collision code has now broken in more than one way across
+// several attempts (see the even earlier predictive, run-every-frame
 // version's own screen-roll failure, previously reverted too - git history
-// on this file has the full account of both), this block is back to the
-// simple, originally-shipped behavior below: revert X and Y together,
+// on this file has the full account), this block is back to the simple,
+// originally-shipped behavior below: revert X and Y together,
 // unconditionally, on any collision - it stops a diagonal move dead at a
 // wall instead of sliding along it, but it's the one version of this that's
 // actually held up.

--- a/src/generators/bbasic/sprites.js
+++ b/src/generators/bbasic/sprites.js
@@ -153,6 +153,10 @@ export const rainbowColorOffsetVarName = (name) => `_${name}RainbowColorOffset`;
 // 255/anything else for "no direction") and a speed (1-7), both captured
 // once at fire time so the per-frame check never has to re-evaluate the
 // original ANGLE/SPEED block inputs.
+// RAM shadow for CTRLPF - see reserveCtrlpfShadowDevVar's own comment for
+// why ball width/priority can't safely read the real hardware register back.
+export const ctrlpfShadowVarName = () => '_ctrlpf';
+
 export const missileFireFlagsVarName = () => '_missileFireFlags';
 export const missileFireActiveBit = (name) => name === 'missile1' ? 1 : 0;
 export const missileFireDirVarName = (name) => `_${name}FireDir`;
@@ -231,6 +235,47 @@ export const reserveMissileFireDevVars = (reserveDevVar, usedFor) => {
     reserveDevVar(missileFireDirVarName(name), undefined, 'this missile\'s fired direction (0-7, or 255 for none)');
     reserveDevVar(missileFireSpeedVarName(name), undefined, 'this missile\'s fired speed (pixels/frame)');
   });
+};
+
+// Ball width and playfield priority both need to read-modify-write CTRLPF -
+// clear just their own bits, keep everything else. That's unsafe done
+// directly against the real hardware register: CTRLPF's write address ($0A)
+// is ALIASED on real 2600 hardware with INPT2 (paddle port 2) in read mode -
+// TIA only decodes 6 address bits and distinguishes write-only vs read-only
+// registers sharing an address purely by the CPU's R/W line, not by the
+// address itself (confirmed directly against vcs.h: CTRLPF and INPT2 are
+// both "ds 1" at the same offset, in TIA_REGISTERS_WRITE and
+// TIA_REGISTERS_READ respectively). So "CTRLPF & 207" doesn't read back
+// whatever was last written to CTRLPF at all - it reads live paddle-port
+// input (open bus/garbage if nothing's plugged in), and OR/ANDing that into
+// a "preserve the other bits" write can set or clear ANY bit, including bit
+// 1 (score mode) - confirmed as the actual root cause of a real reported bug
+// ("ball width flips half the playfield to player1's color"), after ruling
+// out compiler operator-precedence (splitting the multiply into its own
+// statement first didn't fix it either, since the read-back itself was
+// always the problem, however the expression was shaped).
+// This dev var is CTRLPF's own RAM shadow: ball width/priority read-modify-
+// write THIS instead (an ordinary RAM byte, safe to read back), then flush
+// it to the real CTRLPF right after - CTRLPF isn't touched anywhere else in
+// the generated kernel (unlike NUSIZ0/COLUP0/etc, it's never clobbered by
+// the score routine), so a flush immediately after each write is enough;
+// no once-per-frame restore in commongamelogic is needed.
+export const reserveCtrlpfShadowDevVar = (reserveDevVar, used) => {
+  if (!used) return;
+  reserveDevVar(ctrlpfShadowVarName(), undefined,
+      'RAM shadow of CTRLPF - the real register can\'t be safely read back (aliases INPT2)');
+};
+
+// Setup-section one-off (see bbasic.bb.hbs's own generatedCtrlpfShadowSetup
+// splice, right alongside generatedKeypadSetup) - matches startup.asm's own
+// real CTRLPF initial value (reflect bit only) so the shadow and the
+// hardware register agree from the very first ball width/priority write,
+// rather than the shadow starting at 0 (bB's normal all-vars-start-at-zero
+// default) and silently dropping reflect the first time either block runs.
+export const generateCtrlpfShadowSetup = (Blockly) => {
+  if (!Blockly.BBasic.ctrlpfShadowUsed) return '';
+  const shadowVar = Blockly.BBasic.nameDB_.getName(ctrlpfShadowVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+  return ` ${shadowVar} = 1`;
 };
 
 // Spliced into commongamelogic right after generatedAnimations (see this
@@ -446,7 +491,22 @@ export default (Blockly) => {
         // set - a real bug (reported as "changing sprite priority flips the
         // right half of the playfield," since whichever of the two blocks
         // ran later silently undid the other's own bit).
-        return `CTRLPF = (CTRLPF & 207) + (${argument0}) * 16\n`;
+        //
+        // Reads/writes the CTRLPF RAM shadow (see reserveCtrlpfShadowDevVar's
+        // own comment for why the real hardware register can't be safely
+        // read back), flushing it to the real CTRLPF right after. temp1
+        // holds the multiply as its own statement rather than inline (not
+        // the actual root cause of the playfield-flip bug, but still cheap
+        // insurance against batari Basic's own documented history of
+        // compound-expression bugs, e.g. RAND_OPTIONS ruling out division
+        // combined with multiplication in one expression) - safe here, only
+        // clobbered by drawscreen, which can't run mid-statement (see
+        // score.js's own comment on the same convention).
+        const shadowVar = Blockly.BBasic.nameDB_.getName(ctrlpfShadowVarName(),
+            Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+        return `temp1 = (${argument0}) * 16\n` +
+            `${shadowVar} = (${shadowVar} & 207) + temp1\n` +
+            `CTRLPF = ${shadowVar}\n`;
       } else if (varName.endsWith('visibility')) {
         const blockNumber = Blockly.BBasic.blockNumbers.next();
         const baseLabel = `_visibility_${blockNumber}`;
@@ -649,11 +709,16 @@ export default (Blockly) => {
   ['player0', 'player1'].forEach(createGeneratorForPlayer);
   ['missile0', 'missile1'].forEach(createGeneratorForMissile);
 
-  // Bit 2 of CTRLPF. Set through the bit-index syntax rather than a full
-  // assignment so it doesn't clobber the other bits sprite_ball_set already
-  // packs into CTRLPF (reflection, ball width).
+  // Bit 2 of CTRLPF. Set through the bit-index syntax on the CTRLPF RAM
+  // shadow (see reserveCtrlpfShadowDevVar's own comment - real CTRLPF can't
+  // be safely read back), not a full assignment, so it doesn't clobber the
+  // other bits sprite_ball_set already packs into the shadow (reflection,
+  // ball width) - then flushed to the real CTRLPF right after.
   Blockly.BBasic['sprite_priority_set'] = function(block) {
     const value = block.getFieldValue('VALUE');
-    return `CTRLPF{2} = ${value}\n`;
+    const shadowVar = Blockly.BBasic.nameDB_.getName(ctrlpfShadowVarName(),
+        Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+    return `${shadowVar}{2} = ${value}\n` +
+        `CTRLPF = ${shadowVar}\n`;
   };
 };

--- a/src/hooks/project.js
+++ b/src/hooks/project.js
@@ -151,6 +151,13 @@ export const useHideSidebarStorage = () =>
   useBooleanAppSetting('vcs-game-maker.hideSidebar');
 export const useBlocklyControlsHorizontalStorage = () =>
   useBooleanAppSetting('vcs-game-maker.blocklyControlsHorizontal');
+// Same "standing app preference" reasoning as the others here - applies a
+// CSS filter across every block (workspace canvas AND the toolbox/flyout,
+// see BlocklyComponent.vue's own .blocklyDiv binding) rather than touching
+// any block's own colour value, so it works uniformly regardless of which
+// theme/category colours are actually in play.
+export const useDesaturateBlocklyColorsStorage = () =>
+  useBooleanAppSetting('vcs-game-maker.desaturateBlocklyColors');
 export const useHideDescriptionTextStorage = () =>
   useBooleanAppSetting('vcs-game-maker.hideDescriptionText');
 export const useMuteBlocklySoundsStorage = () =>
@@ -163,6 +170,17 @@ export const useMuteBlocklySoundsStorage = () =>
 // navigating away").
 export const useGridSnapStorage = () =>
   useBooleanAppSetting('vcs-game-maker.gridSnap');
+// Same "standing app preference, not a project setting" reasoning as the
+// others above - lets a player switch the Sound tab's own card list between
+// a multi-column grid (the default) and a single full-width column, same
+// choice SoundFXEditor.vue's own .soundfx-list layout has gone back and
+// forth on for itself in the past.
+export const useSoundFxColumnsStorage = () =>
+  useBooleanAppSetting('vcs-game-maker.soundFxColumns', true);
+// Same "standing app preference" reasoning as useSoundFxColumnsStorage
+// above, for the Text tab's own card list (TextEditor.vue's .text-list).
+export const useTextColumnsStorage = () =>
+  useBooleanAppSetting('vcs-game-maker.textColumns', true);
 // Same "standing app preference, not a project setting" reasoning as the
 // others above - a real reported correction (it started out living in
 // configurationState/Project.vue's own configuration bag, meaning it reset

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,1 +1,14 @@
-export const getDateInfix = () => new Date().toISOString().replace(/\..*/, '').replace(/[T:]/g, '-');
+// Same "YYYY-MM-DD-HH-MM-SS" shape the old toISOString()-based version
+// produced, but built from the Date object's own LOCAL getters instead -
+// toISOString() always reports UTC regardless of the user's own timezone,
+// so a save near midnight (or anywhere with a large UTC offset) landed on
+// the wrong calendar day/hour in the filename, confirmed as a real
+// reported "you seem hours off in the filename" mismatch against the
+// user's own clock.
+const pad2 = (n) => String(n).padStart(2, '0');
+
+export const getDateInfix = () => {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}-` +
+    `${pad2(d.getHours())}-${pad2(d.getMinutes())}-${pad2(d.getSeconds())}`;
+};

--- a/src/utils/playfield-coords.js
+++ b/src/utils/playfield-coords.js
@@ -1,0 +1,20 @@
+'use strict';
+
+import {effectiveBackgroundRows} from '../blocks/background';
+
+// Pixel-to-cell math for pfread()-based playfield lookups. Recreated for
+// collision_check_position_box (see generators/bbasic/collision.js) after
+// an earlier version of this file was deleted along with a fully-reverted
+// prior attempt at the same feature - see that file's own top-of-file
+// comment for the account of what broke.
+
+// The playfield is always 32 columns across a 160px-wide screen, regardless
+// of pfres/Superchip - exact, no project config needed.
+export const PF_COLUMN_WIDTH_PX = 5;
+
+// Row height in scanlines depends on how many playfield rows the CURRENT
+// project uses (effectiveBackgroundRows - 11 by default, or pfres directly
+// under Superchip) - matches std_kernel.asm/startup.asm's own default row
+// height calculation ("lda #(96/pfres)"), confirmed against that same
+// 96-scanline-tall half-screen constant.
+export const pfRowDivisorFor = (config) => Math.round(96 / effectiveBackgroundRows(config));

--- a/src/views/Configuration.vue
+++ b/src/views/Configuration.vue
@@ -197,6 +197,13 @@
           class="option-switch"
         />
         <v-switch
+          v-model="desaturateBlocklyColors"
+          label="Soft Blockly colors"
+          hint="Mutes block colors to half their normal saturation for a calmer, less colorful Blockly view."
+          persistent-hint
+          class="option-switch"
+        />
+        <v-switch
           v-model="hideDescriptionText"
           label="Expert mode"
           hint="Hides the small explanatory hint text under fields and switches throughout the app (including this one), for a more compact layout once you already know what everything does."
@@ -211,7 +218,8 @@
 import {computed, defineComponent, ref, watch} from '@vue/composition-api';
 
 import {USER_VARIABLE_LETTERS_WITHOUT_SUPERCHIP} from '../generators/bbasic';
-import {useBackgroundsStorage, useBlocklyControlsHorizontalStorage, useConfigurationStorage, useErrorStorage,
+import {useBackgroundsStorage, useBlocklyControlsHorizontalStorage, useConfigurationStorage,
+  useDesaturateBlocklyColorsStorage, useErrorStorage,
   useHideDescriptionTextStorage, useHideSidebarStorage, useLoadLastProjectStorage, useMuteBlocklySoundsStorage,
   useProjectAutoIncrementVersionStorage} from '../hooks/project';
 import {BANK_COUNT_BY_ROMSIZE, countUsedVariables, usesPlayer0RainbowColors} from '../hooks/rom';
@@ -294,6 +302,7 @@ export default defineComponent({
     const muteBlocklySounds = useMuteBlocklySoundsStorage();
     const hideSidebar = useHideSidebarStorage();
     const blocklyControlsHorizontal = useBlocklyControlsHorizontalStorage();
+    const desaturateBlocklyColors = useDesaturateBlocklyColorsStorage();
     const hideDescriptionText = useHideDescriptionTextStorage();
     const projectAutoIncrementVersion = useProjectAutoIncrementVersionStorage();
 
@@ -481,7 +490,8 @@ export default defineComponent({
       romSizeIsBankswitched,
       player0RainbowColorsActive,
       loadLastProject,
-      muteBlocklySounds, hideSidebar, blocklyControlsHorizontal, hideDescriptionText, projectAutoIncrementVersion,
+      muteBlocklySounds, hideSidebar, blocklyControlsHorizontal, desaturateBlocklyColors,
+      hideDescriptionText, projectAutoIncrementVersion,
       isSectionCollapsed,
       toggleSection,
     };

--- a/src/views/DataEditor.vue
+++ b/src/views/DataEditor.vue
@@ -40,6 +40,25 @@
                   <v-btn
                     icon
                     small
+                    title="Copy this table's contents (values, columns, and value formats)"
+                    class="data-flat-icon-btn data-icon-btn-size"
+                    @click="() => handleCopyTable(table)"
+                  >
+                    <v-icon>mdi-content-copy</v-icon>
+                  </v-btn>
+                  <v-btn
+                    icon
+                    small
+                    :disabled="!copiedTableData"
+                    title="Paste copied contents onto this table"
+                    class="data-flat-icon-btn data-icon-btn-size"
+                    @click="() => handlePasteTable(table)"
+                  >
+                    <v-icon>mdi-content-paste</v-icon>
+                  </v-btn>
+                  <v-btn
+                    icon
+                    small
                     title="Export to .CSV"
                     class="data-flat-icon-btn data-icon-btn-size"
                     @click="() => handleExportCsv(table)"
@@ -316,6 +335,12 @@ const MAX_DATA_TABLE_COLUMNS_DISPLAY = 8;
 const DATA_VALUES_EXTRA_SLACK_PX = 3;
 const DATA_VALUE_CELL_MIN_PX = 120;
 
+// Module-scope (not a ref inside setup()) - same reasoning as
+// BackgroundEditor.vue's own copiedBackgroundData/copiedBackgroundRowColors:
+// keeps the clipboard alive across navigating away from and back to this
+// tab (Vue Router destroys and recreates this component each time).
+const copiedTableData = ref(null);
+
 export default defineComponent({
   components: {ColorSwatchPicker},
   setup() {
@@ -436,6 +461,36 @@ export default defineComponent({
       };
       const sourceIndex = dataTables.findIndex(({id}) => id === table.id);
       dataTables.splice(sourceIndex + 1, 0, newTable);
+      handleChildChange();
+      instance.proxy.$forceUpdate();
+    };
+
+    // Copy/paste the full contents (values/columns/valueFormats) of one
+    // table onto a DIFFERENT existing one - unlike handleDuplicateTable
+    // above (which always creates a brand new table), this overwrites
+    // whatever table you paste it onto, id/name left alone, same "copy the
+    // real content, not the identity" split BackgroundEditor.vue's own
+    // handleCopyBackground/handlePasteBackground already establishes for an
+    // identical copy-onto-an-existing-entry use case.
+    const handleCopyTable = (table) => {
+      copiedTableData.value = {
+        columns: structuredClone(table.columns),
+        values: structuredClone(table.values),
+        valueFormats: structuredClone(table.valueFormats || null),
+      };
+    };
+    // $set (not plain assignment) for columns/valueFormats - same reason as
+    // handleColumnsInput's own comment just below: a table saved before
+    // either field existed can't pick up a brand new property through a
+    // plain assignment, Vue 2 never notices it. values is already always a
+    // real property on every table (see DEFAULT_DATA_TABLES/
+    // processDataTablesStorageDefaults in blocks/data.js), so a plain
+    // reassignment of it is fine.
+    const handlePasteTable = (table) => {
+      if (!copiedTableData.value) return;
+      table.values = structuredClone(copiedTableData.value.values);
+      instance.proxy.$set(table, 'columns', structuredClone(copiedTableData.value.columns));
+      instance.proxy.$set(table, 'valueFormats', structuredClone(copiedTableData.value.valueFormats));
       handleChildChange();
       instance.proxy.$forceUpdate();
     };
@@ -839,6 +894,7 @@ export default defineComponent({
 
     return {
       state, handleChildChange, handleAddTable, handleDeleteTable, handleDuplicateTable,
+      copiedTableData, handleCopyTable, handlePasteTable,
       handleAddValue, handleDeleteValue, handleValueChange, handleSelectValue, handleSubtractValue,
       valueFormat, toggleValueFormat, displayValue, handleValueInput, handleColorValueInput,
       handleDropdownValueInput, dropdownOptionsFor,

--- a/src/views/SoundFXEditor.vue
+++ b/src/views/SoundFXEditor.vue
@@ -28,14 +28,23 @@
           percentage of its own set volume. Off: sound effects play at their
           own set volume.
         </p>
-        <v-select
-          v-model="soundFilter"
-          label="Show"
-          :items="soundFilterItems"
-          hide-details
-          class="soundfx-filter"
-        />
-        <v-list class="soundfx-list">
+        <div class="soundfx-filter-row">
+          <v-select
+            v-model="soundFilter"
+            label="Show"
+            :items="soundFilterItems"
+            hide-details
+            class="soundfx-filter"
+          />
+          <v-switch
+            v-model="soundFxColumns"
+            label="Columns"
+            title="Lay sound effect cards out in multiple columns when there's room, instead of one full-width column."
+            hide-details
+            class="soundfx-columns-switch"
+          />
+        </div>
+        <v-list class="soundfx-list" :class="{'soundfx-list--single-column': !soundFxColumns}">
           <v-list-item
             v-for="(soundEffect, index) in state.soundEffects"
             v-show="matchesSoundFilter(soundEffect)"
@@ -205,6 +214,7 @@
                           title="How often it flips pitch, relative to the song/pattern's own tempo - speeds up and slows down with the song."
                           v-model="soundEffect.arpeggioDivision"
                           :items="arpeggioDivisionOptionItems"
+                          hide-details
                           @change="handleChildChange"
                           class="soundfx-number"
                         />
@@ -215,6 +225,7 @@
                           type="number"
                           :min="MIN_ARPEGGIO_INTERVAL"
                           :max="MAX_ARPEGGIO_INTERVAL"
+                          hide-details
                           @change="handleChildChange"
                           class="soundfx-number"
                         />
@@ -223,12 +234,15 @@
                           title="1 OCT: cycles only between the note's own pitch and pitch+interval. 2 OCT: plays that pattern, then repeats it one octave up before looping back."
                           v-model="soundEffect.arpeggioRange"
                           :items="arpeggioRangeOptionItems"
+                          hide-details
                           @change="handleChildChange"
                           class="soundfx-frequency"
                         />
                       </template>
                     </div>
-                    <div class="soundfx-envelope-block">
+                    <div class="soundfx-envelope-block"
+                      :class="{'soundfx-envelope-block--expanded': soundEffect.envelope}"
+                    >
                       <v-switch
                         v-model="soundEffect.envelope"
                         label="Envelope"
@@ -243,6 +257,7 @@
                           title="Frames to ramp up from silence to full volume."
                           v-model="soundEffect.envelopeAttack"
                           :items="envelopeAttackReleaseFrameOptionItems"
+                          hide-details
                           @change="handleChildChange"
                           class="soundfx-envelope-field"
                         />
@@ -251,6 +266,7 @@
                           title="Frames to ramp down from full volume to the Sustain level."
                           v-model="soundEffect.envelopeDecay"
                           :items="envelopeStageFrameOptionItems"
+                          hide-details
                           @change="handleChildChange"
                           class="soundfx-envelope-field"
                         />
@@ -259,6 +275,7 @@
                           title="The volume level (percent of full volume) held after Attack/Decay, until Release begins."
                           v-model="soundEffect.envelopeSustain"
                           :items="envelopeSustainPercentOptionItems"
+                          hide-details
                           @change="handleChildChange"
                           class="soundfx-envelope-field"
                         />
@@ -267,6 +284,7 @@
                           title="Frames to ramp down from the Sustain level to silence, ending exactly when the sound ends."
                           v-model="soundEffect.envelopeRelease"
                           :items="envelopeAttackReleaseFrameOptionItems"
+                          hide-details
                           @change="handleChildChange"
                           class="soundfx-envelope-field"
                         />
@@ -386,7 +404,8 @@ import {max} from 'lodash';
 
 import {useCollapsedIds} from '../hooks/collapse';
 import {useDragReorder} from '../hooks/drag-reorder';
-import {useDimSoundFxPercentStorage, useDimSoundFxStorage, useSoundEffectsStorage} from '../hooks/project';
+import {useDimSoundFxPercentStorage, useDimSoundFxStorage, useSoundEffectsStorage,
+  useSoundFxColumnsStorage} from '../hooks/project';
 import {AUDC_OPTIONS} from '../blocks/sound';
 import {DEFAULT_SOUND_EFFECTS, processSoundEffectsStorageDefaults, ARPEGGIO_DIVISION_OPTIONS,
   DEFAULT_ARPEGGIO_DIVISION, DEFAULT_ARPEGGIO_INTERVAL, MIN_ARPEGGIO_INTERVAL,
@@ -543,6 +562,7 @@ export default defineComponent({
     // whatever index it's given) keeps working correctly even mid-filter,
     // rather than reordering against filtered-out indices that don't match
     // the real array at all.
+    const soundFxColumns = useSoundFxColumnsStorage();
     const soundFilter = ref('all');
     const soundFilterItems = [
       {text: 'All', value: 'all'},
@@ -712,7 +732,7 @@ export default defineComponent({
       isCollapsed, toggleCollapsed,
       audcHasTunableNotes, frequencyItems, handleAudcChange,
       dimSoundFx, dimSoundFxPercent, dimSoundFxPercentDisplay,
-      soundFilter, soundFilterItems, matchesSoundFilter,
+      soundFxColumns, soundFilter, soundFilterItems, matchesSoundFilter,
       audcOptionItems: AUDC_OPTIONS.map(([text, value]) => ({text, value})),
       arpeggioRangeOptionItems: ARPEGGIO_RANGE_OPTIONS.map(([text, value]) => ({text, value})),
       arpeggioDivisionOptionItems: ARPEGGIO_DIVISION_OPTIONS.map((value) => ({text: `1/${value}`, value})),
@@ -748,22 +768,18 @@ export default defineComponent({
   padding-right: 0;
 }
 
-/* Single column, full width - matches PlayerEditor.vue's own .animation-list
-   (flex column) rather than a multi-column grid, so every card spans the
-   full available width instead of 2+ narrower cards sitting side by side.
-   gap: 0 matches PlayerEditor.vue's own .pixel-editor-parent-container
-   spacing (plain adjacent inline-block frames, no gap of their own). */
+/* Multi-column grid - narrower windows naturally fall back to one column
+   per row once there's no room for a 360px-minimum card beside another. */
 .soundfx-list {
-  display: flex;
-  flex-direction: column;
-  /* Matches PlayerEditor.vue's own .animation-list gap (its top-level entry
-     list - the more apt comparison now that .soundfx-list is single-column
-     top-level entries too, not a grid of cards sitting side by side like a
-     single entry's own frame sub-cards do) - 0 read as too cramped between
-     entire cards, even though it matched .pixel-editor-parent-container's
-     own frame-to-frame spacing fine. */
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 8px;
   margin-top: 12px;
+  /* Grid items stretch to fill their row's height by default - a collapsed
+     card next to an expanded one in the same row would otherwise stretch
+     tall to match it, instead of sitting flush at the top like its card
+     content actually sizes to. */
+  align-items: start;
 }
 
 .entry-list-item >>> .v-list-item__content {
@@ -811,16 +827,44 @@ export default defineComponent({
   margin-top: 8px;
 }
 
+.soundfx-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .soundfx-filter {
   max-width: 220px;
   margin-top: 8px;
 }
 
-/* No max-width (used to cap at 640px, back when .soundfx-list was a
-   multi-column grid and a capped width kept a card from stretching to fill
-   an entire wide grid column on its own) - .soundfx-list is a single,
-   full-width column now (matching PlayerEditor.vue's own .animation-list),
-   so this can just fill 100% of it like every other tab's own main card. */
+/* Same margin-top/padding-top override as .dim-switch elsewhere in this
+   file - Vuetify's own selection-control margin-top (meant for stacking
+   below other fields) otherwise pushes this out of line with the Show
+   select next to it. */
+.soundfx-columns-switch {
+  flex: 0 0 auto;
+  margin-top: 8px !important;
+  padding-top: 0 !important;
+}
+
+/* Single full-width column instead of the grid .soundfx-list defaults to
+   (see that rule's own comment) - toggled via the "Columns" switch above. */
+.soundfx-list--single-column {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Grid's own default stretch (align-items: start on .soundfx-list overrides
+   that for the grid case, but each item still fills its own column width)
+   isn't automatic here - .entry-list-item (Vuetify's own v-list-item, the
+   actual flex child) doesn't stretch to the container's full width on its
+   own, leaving .soundfx-card's own width: 100% only filling 100% of that
+   un-stretched item instead of the whole row. */
+.soundfx-list--single-column .entry-list-item {
+  width: 100%;
+}
+
 /* No max-width (used to cap at 640px) - that was capping each card well
    short of its own 1fr share of .soundfx-list's grid row on a wide window,
    leaving unused space to its right instead of the card actually filling
@@ -1114,8 +1158,19 @@ export default defineComponent({
    stacking in their own row underneath the switch. */
 .soundfx-arpeggio-block, .soundfx-envelope-block {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  /* flex-start, not center - with center, a taller item (e.g. Envelope's
+     own dropdowns) sharing a wrapped line with the switch grows that
+     line's own height, and "center" then pulls the switch down to that
+     line's new midpoint - a real reported bug (the switch visibly shifting
+     position purely from toggling its own fields on, which grow the line
+     it's sharing). flex-start pins every item to the top of its own line
+     regardless of what else joins it there. */
+  align-items: flex-start;
+  /* Separate row/column gap (was a single "gap: 8px") - column spacing
+     between fields on the same row stays 8px, but wrapped rows (narrow
+     window) sit much closer together than that. */
+  row-gap: 8px;
+  column-gap: 8px;
   flex-wrap: wrap;
   width: 100%;
 }
@@ -1127,11 +1182,11 @@ export default defineComponent({
    own extra controls AREN'T also adding their own visual separation
    underneath it. */
 .soundfx-envelope-block {
-  margin-top: 8px;
+  margin-top: 12px;
 }
 
 .hide-description-text .soundfx-envelope-block {
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 /* Arpeggio's own expanded fields already add their own visual separation
@@ -1139,11 +1194,11 @@ export default defineComponent({
    the collapsed case) - the same margin-top on top of THAT read as too
    much. */
 .soundfx-arpeggio-block--expanded + .soundfx-envelope-block {
-  margin-top: 4px;
+  margin-top: 14px;
 }
 
 .hide-description-text .soundfx-arpeggio-block--expanded + .soundfx-envelope-block {
-  margin-top: 4px;
+  margin-top: 14px;
 }
 
 /* Full width so it forces its own line above the graph, same "100%-width
@@ -1153,6 +1208,19 @@ export default defineComponent({
   display: flex;
   width: 100%;
   gap: 4px;
+  /* Breathing room from the Attack/Decay/Sustain/Release fields above
+     (.soundfx-envelope-block's own row-gap is 0, so without this the
+     fields' bottom edge and this row's own divider line sit flush). */
+  margin-top: 8px;
+  /* Right-aligned, under the graph's own right edge (where Release ends),
+     rather than the left edge (where Attack starts). */
+  justify-content: flex-end;
+  /* Separates the graph's own reset/undo/redo controls from the Attack/
+     Decay/Sustain/Release dropdowns above them - same border colour
+     EnvelopeGraph.vue's own .envelope-graph frame uses, so this reads as
+     the same "framed panel" visual language rather than an unrelated line. */
+  padding-top: 6px;
+  border-top: 1px solid rgba(0, 0, 0, 0.24);
 }
 
 /* Same margin-top override as SoundFXEditor's own .dim-switch - Vuetify's
@@ -1165,6 +1233,20 @@ export default defineComponent({
   flex: 0 0 auto;
   margin-top: -4px !important;
   padding-top: 0 !important;
+}
+
+/* Extra push-down ONLY while the block is expanded (fields showing beside
+   the switch) - collapsed, the switch is alone on its own line and the
+   base -4px above already looks right. Under align-items: flex-start (see
+   that rule's own comment for why it replaced center), every item pins to
+   the TOP of its line, which for a v-select/v-text-field means the top of
+   its LABEL text, well above where its actual input box sits - this was
+   applied unconditionally before, which correctly aligned the switch with
+   its fields when expanded but left an oversized gap above a COLLAPSED
+   switch that has no taller sibling to align with at all. */
+.soundfx-arpeggio-block--expanded .soundfx-arpeggio-switch,
+.soundfx-envelope-block--expanded .soundfx-envelope-switch {
+  margin-top: 16px !important;
 }
 
 /* Extra breathing room between each switch's own label text and the field(s)

--- a/src/views/TextEditor.vue
+++ b/src/views/TextEditor.vue
@@ -22,12 +22,22 @@
           <span class="text-bkcolor-label">Text background color</span>
         </div>
 
-        <v-select
-          v-model="textMaxDisplayWidth"
-          :items="TEXT_MAX_DISPLAY_WIDTH_OPTIONS"
-          label="Max characters to display at once"
-          class="text-max-width-field"
-        />
+        <div class="text-max-width-row">
+          <v-select
+            v-model="textMaxDisplayWidth"
+            :items="TEXT_MAX_DISPLAY_WIDTH_OPTIONS"
+            label="Max characters to display at once"
+            hide-details
+            class="text-max-width-field"
+          />
+          <v-switch
+            v-model="textColumns"
+            label="Columns"
+            title="Lay text cards out in multiple columns when there's room, instead of one full-width column."
+            hide-details
+            class="text-columns-switch"
+          />
+        </div>
         <p class="v-messages theme--light v-messages__message">
           For static (non-scrolling) text only. Only the first this-many of the 12 available character
           slots are ever used - the rest always stay blank, regardless of message length or justify. The
@@ -35,7 +45,7 @@
           all 12 character slots.
         </p>
 
-        <v-list class="text-list">
+        <v-list class="text-list" :class="{'text-list--single-column': !textColumns}">
           <v-list-item class="entry-list-item" v-for="(entry, index) in state.textStrings" v-bind:key="entry.id">
             <v-list-item-content>
               <v-card
@@ -166,7 +176,7 @@ import {max} from 'lodash';
 import ColorSwatchPicker from '../components/ColorSwatchPicker.vue';
 import {useCollapsedIds} from '../hooks/collapse';
 import {CSS_CLASS_DRAGGING} from '../hooks/drag-reorder';
-import {useConfigurationStorage, useTextStringsStorage} from '../hooks/project';
+import {useConfigurationStorage, useTextStringsStorage, useTextColumnsStorage} from '../hooks/project';
 import {DEFAULT_TEXT_JUSTIFY, DEFAULT_TEXT_STRINGS, DEFAULT_TEXT_MAX_DISPLAY_WIDTH,
   TEXT_MAX_DISPLAY_WIDTH_OPTIONS, processTextStringsStorageDefaults} from '../blocks/text-strings';
 
@@ -209,6 +219,7 @@ export default defineComponent({
     // blanks the unused tail rather than shrinking storage. Same
     // project-wide, Configuration-storage-backed pattern as textBkColor
     // just above.
+    const textColumns = useTextColumnsStorage();
     const textMaxDisplayWidth = computed({
       get() {
         try {
@@ -368,6 +379,7 @@ export default defineComponent({
     return {
       state, handleChildChange, handleAddEntry, handleDeleteEntry, handleTextChange,
       isCollapsed, toggleCollapsed, textBkColor, textMaxDisplayWidth, TEXT_MAX_DISPLAY_WIDTH_OPTIONS,
+      textColumns,
       dragAttrs, dragCardClass, dragHandleListeners, dragTargetListeners,
     };
   },
@@ -401,8 +413,29 @@ export default defineComponent({
   margin-bottom: 16px;
 }
 
+.text-max-width-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .text-max-width-field {
   max-width: 320px;
+  /* Matches SoundFXEditor.vue's own .soundfx-filter margin-top - without
+     it, this field and .soundfx-filter sit on different baselines, and
+     .text-columns-switch's own offset (tuned to match .soundfx-filter's
+     row) ends up too low relative to this field specifically. */
+  margin-top: 8px;
+}
+
+/* Same margin-top/padding-top override as SoundFXEditor.vue's own
+   .soundfx-columns-switch - Vuetify's own selection-control margin-top
+   (meant for stacking below other fields) otherwise pushes this out of
+   line with the select next to it. */
+.text-columns-switch {
+  flex: 0 0 auto;
+  margin-top: 8px !important;
+  padding-top: 0 !important;
 }
 
 /* A 12-character message doesn't need anywhere near .text-list's own full
@@ -423,6 +456,23 @@ export default defineComponent({
      space above the FIRST row that zeroing v-list-item__content's own
      top padding below removes. */
   margin-top: 12px;
+}
+
+/* Single full-width column instead of the grid .text-list defaults to
+   above - toggled via the "Columns" switch next to the max-width field.
+   Same shape as SoundFXEditor.vue's own .soundfx-list--single-column. */
+.text-list--single-column {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Grid stretches each item to fill its own column width automatically -
+   flex doesn't do that for .entry-list-item (Vuetify's own v-list-item, the
+   actual flex child) on its own, leaving .text-card's own width: 100% only
+   filling 100% of that un-stretched item instead of the whole row. Same
+   fix as SoundFXEditor.vue's own equivalent rule. */
+.text-list--single-column .entry-list-item {
+  width: 100%;
 }
 
 /* v-list-item__content's default 12px top/bottom padding was adding extra


### PR DESCRIPTION
Bug fixes:
  - Fixed ball-width setter scrambling unrelated CTRLPF bits (reported as "setting ball width flips half the playfield to player1's color").
  - Fixed a Vuetify dialog bug where the modal backdrop (scrim) could render above the dialog's own buttons, making them unclickable (reported as "Create New Project" doing nothing when clicked).
  - Fixed the emulator preview drawer auto-switching into "temporary" (with a dark backdrop) at narrow viewport widths - now always renders as a permanent panel.
  - Fixed save filename not using the browser's local timezone.
  - Fixed auto-increment version not updating the save filename after navigating away and back.

Envelope (ADSR) graph editor polish:
  - Release dot now drags vertically to adjust release length.

Sound FX / Text tab layout:
  - Added a "Columns" toggle to switch each tab's card list between a multi-column grid and a single full-width column.