### PR TITLE
Text Minikernel scroll cursor, row/score padding, and Save/Open iframe fix (0.50.31)

### DIFF
--- a/background.js
+++ b/background.js
@@ -104,6 +104,65 @@ ipcMain.handle('stella:launch', async (event, {stellaPath, romBytes}) => {
   });
 });
 
+// Project.vue's own "Save"/"Save As"/"Open Project" - the renderer's
+// SUPPORTS_FILE_SYSTEM_ACCESS check (window.showSaveFilePicker/
+// showOpenFilePicker) is always false in this Electron build (that API
+// isn't exposed to Electron renderers the way it is in Chrome), so without
+// these, "Save" silently fell all the way back to "Save As..." behavior
+// (a picker on every click) - a real reported bug, not the intended
+// browsers-only fallback that check's own comment describes. These give
+// the desktop build its own equivalent: a real native save/open dialog
+// backed by Node's fs, with the resulting absolute path handed back to the
+// renderer to remember for later silent "Save" calls (see
+// utils/file-handle-storage.js's own persistActiveFilePath).
+ipcMain.handle('project:save-as', async (event, {content, suggestedName}) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const result = await dialog.showSaveDialog(win, {
+    title: 'Save VCS Game Maker Project',
+    defaultPath: suggestedName,
+    filters: [{name: 'VCS Game Maker Project', extensions: ['vcsgm']}],
+  });
+  if (result.canceled || !result.filePath) return null;
+  fs.writeFileSync(result.filePath, content, 'utf8');
+  return {path: result.filePath, name: path.basename(result.filePath)};
+});
+
+ipcMain.handle('project:save', async (event, {filePath, content}) => {
+  try {
+    fs.writeFileSync(filePath, content, 'utf8');
+    return true;
+  } catch (err) {
+    console.error('Error while saving project file', err);
+    return false;
+  }
+});
+
+ipcMain.handle('project:open', async (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const result = await dialog.showOpenDialog(win, {
+    title: 'Open VCS Game Maker Project',
+    properties: ['openFile'],
+    filters: [{name: 'VCS Game Maker Project', extensions: ['vcsgm']}],
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  const filePath = result.filePaths[0];
+  const content = fs.readFileSync(filePath, 'utf8');
+  return {path: filePath, name: path.basename(filePath), content};
+});
+
+// Used to double-check a path restored from a previous session (see
+// utils/file-handle-storage.js's own loadPersistedFilePath) still points
+// at a real file before trusting it as a silent "Save" target - the file
+// may have been moved/deleted since, the Electron-side equivalent of the
+// browser path's own queryPermission() === 'denied' check.
+ipcMain.handle('project:path-exists', async (event, filePath) => {
+  try {
+    return fs.existsSync(filePath);
+  } catch (err) {
+    return false;
+  }
+});
+
 // Explicit Edit menu (rather than relying on Electron's implicit default
 // menu) so Ctrl+C/Cut/Paste/Select All accelerators are guaranteed to be
 // wired up - covers plain selectable text (e.g. the error console) as well

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vcs-game-maker",
   "productName": "VCS Game Maker",
-  "version": "0.50.30",
+  "version": "0.50.31",
   "private": true,
   "description": "A no-code environment for creating Atari 2600 games using Blockly and batari Basic.",
   "author": "haroldo-ok, with contributions by AbstractPolygon",

--- a/preload.js
+++ b/preload.js
@@ -13,4 +13,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // cloned across the IPC boundary automatically, no manual serialization
   // needed.
   launchStella: (stellaPath, romBytes) => ipcRenderer.invoke('stella:launch', {stellaPath, romBytes}),
+  saveProjectAs: (content, suggestedName) => ipcRenderer.invoke('project:save-as', {content, suggestedName}),
+  saveProject: (filePath, content) => ipcRenderer.invoke('project:save', {filePath, content}),
+  openProject: () => ipcRenderer.invoke('project:open'),
+  projectPathExists: (filePath) => ipcRenderer.invoke('project:path-exists', filePath),
 });

--- a/public/bb19/text-minikernel/text12a.asm
+++ b/public/bb19/text-minikernel/text12a.asm
@@ -23,6 +23,15 @@ scorecount = 7
 textbkcolor=0
  endif
 
+ ; vcs-game-maker: 0/1/2 - the Score tab's own "Add score padding" dropdown
+ ; (generators/bbasic.js's own scorePaddingConfigurationCode). Always
+ ; defined so "if scorepaddinglines >= N" (a plain compile-time expression,
+ ; not an ifconst) is always valid, even for a project that's never visited
+ ; that dropdown.
+ ifnconst scorepaddinglines
+scorepaddinglines = 0
+ endif
+
 
  
 minikernel
@@ -158,6 +167,66 @@ begintextscore
          sty GRP0                   ; 3     (56)
          dey                        ; 2     (58)
          bpl textscoreloop          ; 3     (61)
+         ; vcs-game-maker: scorepaddinglines (0, 1, or 2 - the Score tab's
+         ; own "Add score padding" dropdown, generators/bbasic.js's own
+         ; scorePaddingConfigurationCode) extra scanlines of the score's own
+         ; background color, between the digits finishing and whatever draws
+         ; next (the text minikernel) - inside this same "ifnconst
+         ; noscoretxt" block, so they only exist for a project that actually
+         ; shows the numeric score. Always defined (defaulting to 0), so
+         ; "if scorepaddinglines >= N" below is always a valid compile-time
+         ; check, not an ifconst.
+         if scorepaddinglines >= 1
+             ; GRP0/GRP1 still hold the last digit row's own pixels here
+             ; (nothing clears them when the loop exits) - blanked the same
+             ; 3-write way "textrowsdone"/"textkernel2ndrow" already do
+             ; elsewhere in this kernel (the double GRP0 write flushes
+             ; VDELP's own old-value latch too, not just the top write) -
+             ; without this, the new scanline below started out by visibly
+             ; repeating the last digit row instead of showing a plain
+             ; background fill (confirmed directly against a real build).
+             lda #0
+             sta GRP0
+             sta GRP1
+             sta GRP0
+             ; The loop above ends mid-scanline (no WSYNC of its own after
+             ; the last iteration, see the cycle annotations) - this WSYNC
+             ; closes out whatever's left of that scanline (now blanked, not
+             ; a stale digit row) and starts a fresh one for the background
+             ; fill below.
+             sta WSYNC
+             ifconst scorebkcolor
+                 lda scorebkcolor
+                 sta COLUBK
+             endif
+         endif
+         if scorepaddinglines >= 2
+             ; A second line of the same fill - same reasoning as the first.
+             sta WSYNC
+             ifconst scorebkcolor
+                 lda scorebkcolor
+                 sta COLUBK
+             endif
+         endif
+         if scorepaddinglines >= 1
+             ; Without this, the cleanup code right after this block
+             ; (eventually setting COLUBK to textbkcolor) runs on this SAME
+             ; scanline with no WSYNC of its own in between - splitting this
+             ; line into two colors partway across instead of the solid,
+             ; full-width fill intended (confirmed directly against a real
+             ; build).
+             sta WSYNC
+             ; textbkcolor doesn't otherwise get set until partway into the
+             ; cleanup code below (~24 cycles into this scanline) - without
+             ; setting it immediately here too, scorebkcolor's own fill
+             ; bleeds into the start of this next scanline until that later
+             ; write catches up (confirmed directly against a real build).
+             ; The cleanup code's own later "lda #textbkcolor / sta COLUBK"
+             ; becomes redundant once this runs, but harmless - same value
+             ; either way.
+             lda #textbkcolor
+             sta COLUBK
+         endif
     endif
 
 score_loop_height = * - textscoreloop
@@ -169,8 +238,22 @@ score_loop_height = * - textscoreloop
 	sty GRP0                ; 3     (73)
 	sty GRP1                ; 3     (76/0)
 	sty GRP0                ; 3     (3)
-	lda #textbkcolor
-	sta COLUBK              ; 3     (6)
+	; vcs-game-maker: when noscoretxt is unset (score digits shown) AND
+	; scorepaddinglines is at least 1, the "ifnconst noscoretxt" block above
+	; (right after the score loop) already set COLUBK to textbkcolor
+	; immediately after its own extra scanline(s) - this one would just be a
+	; harmless but redundant repeat in that case, so it's skipped. Otherwise
+	; (pure text mode, or score padding off) this remains the only place
+	; that sets it.
+	ifconst noscoretxt
+	    lda #textbkcolor
+	    sta COLUBK              ; 3     (6)
+	else
+	    if scorepaddinglines < 1
+	        lda #textbkcolor
+	        sta COLUBK              ; 3     (6)
+	    endif
+	endif
 
     ifconst extendedtxt
     sty TextDataPtr+1              ; 3     (9)

--- a/public/bb19/text-minikernel/text12b.asm
+++ b/public/bb19/text-minikernel/text12b.asm
@@ -77,6 +77,21 @@ userealrow2
         clc
         adc #12
 gotrow2base
+        ; vcs-game-maker row2-color hook - utils/text-font.js's own
+        ; buildTextRow2ColorOverride splices a "pha/lda <resolved var>/sta
+        ; COLUP0/sta COLUP1/pla" sequence right after this comment when row
+        ; 2 is actually used (never touched otherwise). Row 2's own color is
+        ; a real dev var (settable via the "Text: set row 2 color" block),
+        ; not a compile-time const like textbkcolor - its real resolved name
+        ; isn't known when this vendored file is written, so it can't be
+        ; hardcoded here the way TextColor/TextIndex/TextRow2Active are (see
+        ; hooks/rom.js). A holds row 2's own base offset into text_strings
+        ; on entry here (from either path above) - showtextrow needs it
+        ; untouched, so the spliced code saves/restores it around the color
+        ; set rather than clobbering it (an earlier version did just that,
+        ; corrupting row 2's own offset and reading garbage bytes from
+        ; wherever that clobbered value pointed instead - visibly, scrambled
+        ; row 2 text).
         jsr showtextrow
     endif
     jmp textrowsdone
@@ -87,17 +102,57 @@ gotrow2base
 ; "textkernel2ndrow" above) and reading downward from base+11 to base, then
 ; draws the row. A tail call (not a nested jsr) into drawtextrow below -
 ; its own rts returns straight to showtextrow's caller.
+;
+; Unrolled (originally a dey/dex/bpl loop) - vcs-game-maker: this runs with
+; no WSYNC of its own between row 1's own drawing and row 2's (see
+; "textkernel2ndrow" in textkernel above), so its own cost IS the visible
+; gap between the two text rows. The loop form cost ~192 cycles here every
+; time a row is filled; this unrolled form costs ~118 - close enough to one
+; scanline's worth (~76 cycles) less that row 2 now starts one scanline
+; earlier. Row 1's own call site has slack before its first WSYNC (nothing
+; upstream of it overflows a scanline boundary the loop form didn't already
+; fit inside), so only row 2's start position actually moves - larger in
+; ROM bytes than the loop form, but this file has no per-project runtime
+; state to preserve here, so that's a fixed, one-time cost.
 showtextrow
     clc
     adc #11
     tay
-    ldx #11
-TextPointersLoop
     lda (TextDataPtr),y
-    sta scorepointers,x
+    sta scorepointers+11
     dey
-    dex
-    bpl TextPointersLoop
+    lda (TextDataPtr),y
+    sta scorepointers+10
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+9
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+8
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+7
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+6
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+5
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+4
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+3
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+2
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+1
+    dey
+    lda (TextDataPtr),y
+    sta scorepointers+0
     jmp drawtextrow
 
 ; One row's own cycle-exact 5-line (10-scanline) draw, reading whatever
@@ -443,6 +498,13 @@ textrowsdone
     sta NUSIZ1
     sta VDELP0
     sta VDELP1
+
+    ; vcs-game-maker scroll-cursor hook - utils/text-font.js's own
+    ; buildTextScrollCursorOverride splices a per-project "more below"
+    ; indicator right after this comment when that feature is on (never
+    ; touched at all otherwise). Player0/GRP0 (used there) is free here for
+    ; the exact same reason the rest of this kernel already reuses it -
+    ; nothing after this point needs it again before the return below.
 
     ifconst textbank
         sta temp7

--- a/release-notes-0.50.30.txt
+++ b/release-notes-0.50.30.txt
@@ -1,0 +1,14 @@
+0.50.27
+- Score fade shading (scorefade) on the Score tab
+- Disabled the Background tab's XY toggle unless the pixel grid is on
+- Player tab frame/animation ID badge tweaks
+- Aligned the Score/Text background-color label sizes
+
+0.50.29
+- Added: 16-glyph custom score fonts, a random seed block, a score digit change block, native bB function blocks, Atari Keypad controller support, a pixel grid overlay for the Player Sprite/Background editors, score background color and background/playfield color getter blocks, horizontal Blockly controls, background/score/text color fade blocks, Expert mode, Project tab info fields (Title/Developer/Version/Website/Email/Description), an auto-increment version option, and Data table cell types
+
+0.50.30
+- Multiline Text-card fields with newline-aware word wrap
+- New "Scroll text lines up/down" runtime blocks for the Text Minikernel (supports messages longer than 2 lines)
+- Manual pfrowheight override field on the Options tab
+- Fixed a missing rts in the Text Minikernel's row-drawing routine that was causing glyph corruption and screen rolling

--- a/src/blocks/background.js
+++ b/src/blocks/background.js
@@ -58,7 +58,18 @@ const BACKGROUND_COLOR = '#ffa500';
 // generators/bbasic/background.js) - nothing else overwrites scorecolor or
 // TextColor every frame the way the score/text drawing routines overwrite
 // COLUBK/COLUPF, so the real variable itself doubles as its own shadow.
-const FADE_TAG_BY_VAR = {COLUBK: 'bg', COLUPF: 'pf', scorecolor: 'score', TextColor: 'text'};
+// player0realcolor/player1realcolor (sprites.js's own sprite_player_fade_to)
+// share this same mechanism too, feeding COLUP0/COLUP1 - see
+// generateBackgroundFadeChecks' own isShadowedRegister check for why these
+// two DO need nameDB_ resolution (like COLUBK/COLUPF), unlike scorecolor/
+// TextColor. Fading either one also fades that player's own missile
+// (missile0/missile1) for free: real 2600 hardware has no separate missile
+// color register at all - missile0 always draws in COLUP0, missile1 in
+// COLUP1, the exact same registers Player 0/1's own color already lives in.
+const FADE_TAG_BY_VAR = {
+  COLUBK: 'bg', COLUPF: 'pf', scorecolor: 'score', TextColor: 'text',
+  player0realcolor: 'p0', player1realcolor: 'p1',
+};
 const fadeTag = (rawVar) => FADE_TAG_BY_VAR[rawVar] || rawVar;
 export const backgroundFadeTimerVarName = (rawVar) => `_${fadeTag(rawVar)}FadeTimer`;
 export const backgroundFadePaceVarName = (rawVar) => `_${fadeTag(rawVar)}FadePace`;
@@ -83,11 +94,16 @@ export const backgroundFadeTargetVarName = (rawVar) => `_${fadeTag(rawVar)}FadeT
 export const FADE_STEPS = 4;
 
 // One shared byte covers both the "fade finished" watch flags AND the "fade
-// currently active" flags for all four fadeable registers - exactly 8 bits
-// total (4 registers x 1 for "finished", plus 4 registers x 1 for
-// "active"), filling the byte exactly, so fixed bits are simpler than the
+// currently active" flags for up to four fadeable registers at once - 8 bits
+// total (up to 4 registers x 1 for "finished", plus up to 4 registers x 1
+// for "active"), filling a byte exactly, so fixed bits are simpler than the
 // Music tab's own pooled/overflow allocation (built for open-ended,
-// user-defined watch counts) and never need more than this one byte.
+// user-defined watch counts) and never need more logic than a second byte
+// once a 5th+ register needs the same machinery. COLUBK/COLUPF/scorecolor/
+// TextColor fill the first byte exactly; player0realcolor/player1realcolor
+// (sprites.js's own sprite_player_fade_to) get their own second byte
+// (FADE_FLAGS_BYTE_BY_VAR/FADE_FLAGS_REGISTER_GROUPS below), since the first
+// one has no bits left to spare.
 // "Finished" fires regardless of which way the fade was moving (brightening
 // or dimming) - background_fade_finished used to have its own DIRECTION
 // dropdown splitting this by direction, but that meant a project reacting
@@ -98,9 +114,21 @@ export const FADE_STEPS = 4;
 // (generateBackgroundFadeChecks) reads to know whether a register has an
 // in-progress fade to keep stepping at all - set once by the matching
 // trigger block's own code (background_fade_to/score_fade_to/
-// text_minikernel_fade_to), cleared once the check steps the color onto its
-// exact target.
-export const fadeFlagsVarName = () => '_fadeFlags';
+// text_minikernel_fade_to/sprite_player_fade_to), cleared once the check
+// steps the color onto its exact target.
+const FADE_FLAGS_BYTE_BY_VAR = {
+  COLUBK: 1, COLUPF: 1, scorecolor: 1, TextColor: 1,
+  player0realcolor: 2, player1realcolor: 2,
+};
+export const fadeFlagsVarName = (rawVar) => FADE_FLAGS_BYTE_BY_VAR[rawVar] === 2 ? '_fadeFlags2' : '_fadeFlags';
+// Which registers share each of fadeFlagsVarName's own two possible bytes -
+// read by bbasic.js's own init() to decide which byte(s) actually need
+// reserving for a given project (a project fading only Player colors never
+// pays for the Background/Score/Text byte, and vice versa).
+export const FADE_FLAGS_REGISTER_GROUPS = [
+  ['COLUBK', 'COLUPF', 'scorecolor', 'TextColor'],
+  ['player0realcolor', 'player1realcolor'],
+];
 // Scratch storage for background_get_pixel's own X/Y, ONLY when a non-bare
 // expression (e.g. "xCycle - 1") is plugged into one of its sockets (see
 // generators/bbasic/background.js) - pfread()'s own arguments can't contain
@@ -124,8 +152,14 @@ export const backgroundGetPixelYVarName = () => '_bgGetPixelY';
 // comment). Bits 4-7: the matching "active" bit for that same register
 // (FADE_ACTIVE_BIT_BY_VAR below) - always exactly 4 apart from its own
 // "finished" bit, which is what backgroundFadeFinishedBit derives from
-// rather than keeping a second, parallel map in sync by hand.
-const FADE_ACTIVE_BIT_BY_VAR = {COLUBK: 4, COLUPF: 5, scorecolor: 6, TextColor: 7};
+// rather than keeping a second, parallel map in sync by hand. Player0/
+// player1 reuse the exact same 0-3/4-7 layout, just within their OWN byte
+// (fadeFlagsVarName('player0realcolor') !== fadeFlagsVarName('COLUBK')) -
+// bit numbers can safely repeat across the two bytes.
+const FADE_ACTIVE_BIT_BY_VAR = {
+  COLUBK: 4, COLUPF: 5, scorecolor: 6, TextColor: 7,
+  player0realcolor: 4, player1realcolor: 5,
+};
 export const fadeActiveBit = (rawVar) => FADE_ACTIVE_BIT_BY_VAR[rawVar];
 export const backgroundFadeFinishedBit = (rawVar) => FADE_ACTIVE_BIT_BY_VAR[rawVar] - 4;
 
@@ -144,12 +178,13 @@ export const backgroundFadeWatchKey = (rawVar) => rawVar;
 // score_fade_finished/text_minikernel_fade_finished have no VAR dropdown of
 // their own (same reasoning as score_fade_to/text_minikernel_fade_to - see
 // their own comments: there's only one possible score/text color register,
-// so offering a choice would be pointless) - only background_fade_finished
-// actually reads one.
+// so offering a choice would be pointless) - only background_fade_finished/
+// sprite_player_fade_finished (Player 0/Player 1) actually read one.
 const FADE_FINISHED_RAW_VAR_BY_TYPE = {
   background_fade_finished: (block) => block.getFieldValue('VAR'),
   score_fade_finished: () => 'scorecolor',
   text_minikernel_fade_finished: () => 'TextColor',
+  sprite_player_fade_finished: (block) => block.getFieldValue('VAR'),
 };
 export const resolveBackgroundFadeFinishedWatches = (workspace) => {
   const watched = new Set();
@@ -161,15 +196,28 @@ export const resolveBackgroundFadeFinishedWatches = (workspace) => {
   return watched;
 };
 
-// Whether any background_fade_active block exists anywhere in the project -
-// that block reads fadeFlagsVarName's own active bit directly (see
-// its generator in generators/bbasic/background.js), so the shared byte it
-// lives in needs to be reserved even in the (unusual, but valid) case of a
-// project checking "is this fade active" on a register that has no
-// background_fade_to block of its own - the check just always reads false
-// then, same as a fade that was never triggered.
-export const hasBackgroundFadeActiveChecks = (workspace) =>
-  workspace.getAllBlocks(false).some((block) => block.type === 'background_fade_active');
+// Every register some "is this fade active" block (background_fade_active
+// OR sprite_player_fade_active) actually reads - either block reads
+// fadeFlagsVarName's own active bit directly (see their generators in
+// generators/bbasic/background.js and generators/bbasic/sprites.js), so
+// whichever byte a given register lives in needs to be reserved even in the
+// (unusual, but valid) case of a project checking "is this fade active" on
+// a register that has no matching fade_to block of its own - the check just
+// always reads false then, same as a fade that was never triggered. Returns
+// a Set of raw var names (not a plain boolean) so bbasic.js's own init() can
+// tell which of fadeFlagsVarName's own two possible bytes each one needs.
+const FADE_ACTIVE_CHECK_RAW_VAR_BY_TYPE = {
+  background_fade_active: (block) => block.getFieldValue('VAR'),
+  sprite_player_fade_active: (block) => block.getFieldValue('VAR'),
+};
+export const hasBackgroundFadeActiveChecks = (workspace) => {
+  const found = new Set();
+  workspace.getAllBlocks(false).forEach((block) => {
+    const rawVarFor = FADE_ACTIVE_CHECK_RAW_VAR_BY_TYPE[block.type];
+    if (rawVarFor) found.add(rawVarFor(block));
+  });
+  return found;
+};
 
 // Default color byte for a playfield row when per-row colors (pfcolors) are
 // enabled: $0E, the same light grey the playfield uses by default, so switching

--- a/src/blocks/sprites.js
+++ b/src/blocks/sprites.js
@@ -747,3 +747,100 @@ Blockly.defineBlocksWithJsonArray([
       `per-sprite - but it can be changed at any time during the game.`,
   },
 ]);
+
+// Fading Player 0/Player 1's color - same shared mechanism as Background's
+// own "Fade color to" (see emitColorFadeTrigger in generators/bbasic/
+// background.js, generalized past just COLUBK/COLUPF/scorecolor/TextColor
+// to cover player0realcolor/player1realcolor too - see blocks/background.js's
+// own FADE_TAG_BY_VAR/FADE_FLAGS_BYTE_BY_VAR). One combined VAR dropdown
+// covering both players (same "one combined block instead of one per
+// player/missile/ball" convention as object_seek_to/object_seek_arrived
+// above), targeting the exact same player0realcolor/player1realcolor system
+// variables the "Color" option on sprite_player0_get/sprite_player0_set
+// already reads/writes (buildPlayerOptions above).
+//
+// Also fades the matching missile (missile0 for Player 0, missile1 for
+// Player 1) with no extra code needed: real 2600 hardware has no separate
+// missile color register at all - missile0 always draws using COLUP0 (the
+// exact same register Player 0's own color lives in), missile1 uses COLUP1 -
+// so fading player0realcolor/player1realcolor (which feed COLUP0/COLUP1
+// every frame - see bbasic.bb.hbs's own "COLUP0 = player0realcolor") already
+// fades whichever missile is paired with that player too.
+const PLAYER_FADE_VAR_OPTIONS = [
+  [`${PLAYER_ICON} Player 0`, 'player0realcolor'],
+  [`${PLAYER_ICON} Player 1`, 'player1realcolor'],
+];
+const PLAYER_FADE_COLOUR = 'purple';
+
+Blockly.defineBlocksWithJsonArray([
+  {
+    'type': `sprite_player_fade_to`,
+    'message0': `${PLAYER_ICON} Fade %1 ${COLOR_ICON} color to %2 over %3 frames`,
+    'args0': [
+      {
+        'type': 'field_dropdown',
+        'name': 'VAR',
+        'options': PLAYER_FADE_VAR_OPTIONS,
+      },
+      {
+        'type': 'input_value',
+        'name': 'VALUE',
+      },
+      {
+        'type': 'input_value',
+        'name': 'FRAMES',
+        'check': 'Number',
+      },
+    ],
+    'inputsInline': true,
+    'previousStatement': null,
+    'nextStatement': null,
+    'colour': PLAYER_FADE_COLOUR,
+    'tooltip': 'Starts fading Player 0 or Player 1\'s color toward the given color over roughly ' +
+      'this many frames - same hue as the target, brightness automatically climbing or dropping ' +
+      'from wherever it currently is, whichever direction actually gets closer. Only needs to be ' +
+      'triggered once - the fade keeps running by itself every frame afterward, even from inside ' +
+      'an "if" block that only briefly becomes true, until it reaches the target and stops. Also ' +
+      'fades that player\'s own missile (missile0 for Player 0, missile1 for Player 1) for free - ' +
+      'on real Atari 2600 hardware, a missile always shares its player\'s own color register, so ' +
+      'there\'s no separate missile color to fade.',
+  },
+]);
+
+// Works exactly like background_fade_finished (see blocks/background.js's
+// own comment - same shared bit/flag machinery, same "fires once, regardless
+// of fade direction, never late" behavior), just choosing between Player 0/
+// Player 1 instead of Background/Playfield.
+Blockly.Blocks['sprite_player_fade_finished'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField(`${PLAYER_ICON} When`)
+        .appendField(new Blockly.FieldDropdown(PLAYER_FADE_VAR_OPTIONS), 'VAR')
+        .appendField(`${COLOR_ICON} color has finished fading`);
+    this.appendStatementInput('DO');
+    this.setPreviousStatement(true);
+    this.setNextStatement(true);
+    this.setColour(PLAYER_FADE_COLOUR);
+    this.setTooltip('Runs the connected blocks once, the moment a matching "Fade" block (same ' +
+      'Player 0/Player 1 choice) reaches its own target color. Does nothing if no matching fade ' +
+      'ever runs anywhere in the project.');
+  },
+};
+
+// Plain, always-current boolean read of the active bit - same shape as
+// background_fade_active's own generator (see blocks/background.js's own
+// comment), just choosing between Player 0/Player 1 instead of Background/
+// Playfield.
+Blockly.Blocks['sprite_player_fade_active'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField(`${PLAYER_ICON} Is`)
+        .appendField(new Blockly.FieldDropdown(PLAYER_FADE_VAR_OPTIONS), 'VAR')
+        .appendField(`${COLOR_ICON} color fade active?`);
+    this.setOutput(true, 'Boolean');
+    this.setColour(PLAYER_FADE_COLOUR);
+    this.setTooltip('True while Player 0 or Player 1\'s color is in the middle of a "Fade" - from ' +
+      'the moment a "Fade" block triggers it until it reaches its own target color, false the ' +
+      'rest of the time.');
+  },
+};

--- a/src/blocks/text-minikernel.js
+++ b/src/blocks/text-minikernel.js
@@ -141,7 +141,29 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     'type': 'text_minikernel_set_color',
-    'message0': `${COLOR_ICON} Text set color to %1`,
+    'message0': `${COLOR_ICON} Text set %1 color to %2`,
+    'args0': [
+      {
+        'type': 'field_dropdown',
+        'name': 'ROW',
+        'options': [['row 1', '1'], ['row 2', '2'], ['both', 'both']],
+      },
+      {
+        'type': 'input_value',
+        'name': 'VALUE',
+      },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+    'colour': TEXT_COLOR,
+    'tooltip': 'Sets the color of Text Minikernel messages - "row 2" only matters for a wrapped ' +
+      'message\'s second line (a message with "Wrap to line 2" on, or one long enough to ' +
+      'word-wrap that far on its own). Defaults to "row 1", matching this block\'s own old, ' +
+      'row-1-only behavior before this dropdown existed.',
+  },
+  {
+    'type': 'text_minikernel_set_cursor_color',
+    'message0': `${COLOR_ICON} Text set scroll cursor color to %1`,
     'args0': [
       {
         'type': 'input_value',
@@ -151,7 +173,23 @@ Blockly.defineBlocksWithJsonArray([
     'previousStatement': null,
     'nextStatement': null,
     'colour': TEXT_COLOR,
-    'tooltip': 'Sets the color of Text Minikernel messages.',
+    'tooltip': 'Sets the color of the blinking scroll cursor (Text tab\'s "Show a blinking scroll ' +
+      'cursor" switch).',
+  },
+  {
+    'type': 'text_minikernel_set_end_icon_color',
+    'message0': `${COLOR_ICON} Text set end icon color to %1`,
+    'args0': [
+      {
+        'type': 'input_value',
+        'name': 'VALUE',
+      },
+    ],
+    'previousStatement': null,
+    'nextStatement': null,
+    'colour': TEXT_COLOR,
+    'tooltip': 'Sets the color of the "end of message" icon that appears once there\'s nothing ' +
+      'left to scroll down to.',
   },
   // Fades TextColor toward a target - same shared mechanism as Background's
   // own "Fade color to" (see blocks/background.js's own fade var-name
@@ -249,32 +287,63 @@ Blockly.defineBlocksWithJsonArray([
       'chosen end of its scroll range (always true for "Left" on a message that never ' +
       'needed to scroll at all).',
   },
-  // Moves the currently shown message up/down one line at a time when its
-  // own "Wrap to line 2" text (see the Text tab's own multi-line field) has
-  // more than 2 lines - only the first 2 are ever shown at once, same as
-  // any other wrapping message. Distinct from the "Text scroll" blocks
-  // above (which move a single line horizontally, character by character) -
-  // these move vertically, whole lines at a time. Harmless no-ops on a
-  // message with 2 or fewer lines, or one shown via a "(scrolling)" block.
+  {
+    'type': 'text_minikernel_end_icon_visible',
+    'message0': `${TEXT_ICON} End of text?`,
+    'output': 'Boolean',
+    'colour': TEXT_COLOR,
+    'tooltip': 'True whenever the "end of message" icon would currently be showing - ' +
+      'i.e. there\'s nothing left below the currently shown message to scroll down to.',
+  },
+  // Moves the currently shown message up/down one or two lines at a time
+  // whenever its own text (the Text tab's own multi-line field) is more than
+  // 2 lines - works regardless of whether "Wrap to line 2" is on: that
+  // toggle only decides whether line 2 draws automatically without
+  // scrolling, not whether a message's own overflow text is split into real,
+  // separate lines at all (a long message always word-wraps into more than
+  // one line, on or off). Distinct from the "Text scroll" blocks above
+  // (which move a single line horizontally, character by character) - these
+  // move vertically, whole lines at a time. Harmless no-ops on a message
+  // with 2 or fewer lines, or one shown via a "(scrolling)" block.
   {
     'type': 'text_minikernel_line_scroll_up',
-    'message0': `${TEXT_ICON} Scroll text lines up`,
+    'message0': `${TEXT_ICON} Scroll text lines up %1`,
+    'args0': [
+      {
+        'type': 'field_dropdown',
+        'name': 'LINES',
+        'options': [['1 line', '1'], ['2 lines', '2']],
+      },
+    ],
+    'inputsInline': true,
     'previousStatement': null,
     'nextStatement': null,
     'colour': TEXT_COLOR,
-    'tooltip': 'Moves the currently shown message up by one line, revealing an earlier line ' +
-      'of a "Wrap to line 2" message with more than 2 lines. Has no effect once already at ' +
-      'the first line, or on a message with 2 or fewer lines.',
+    'tooltip': 'Moves the currently shown message up by one or two lines (your choice above), ' +
+      'revealing an earlier line of a message with more than 2 lines - works whether or not ' +
+      '"Wrap to line 2" is on for it. Never moves earlier than the first line, even if that ' +
+      'means moving by less than the chosen amount - and has no effect at all on a message ' +
+      'with 2 or fewer lines.',
   },
   {
     'type': 'text_minikernel_line_scroll_down',
-    'message0': `${TEXT_ICON} Scroll text lines down`,
+    'message0': `${TEXT_ICON} Scroll text lines down %1`,
+    'args0': [
+      {
+        'type': 'field_dropdown',
+        'name': 'LINES',
+        'options': [['1 line', '1'], ['2 lines', '2']],
+      },
+    ],
+    'inputsInline': true,
     'previousStatement': null,
     'nextStatement': null,
     'colour': TEXT_COLOR,
-    'tooltip': 'Moves the currently shown message down by one line, revealing a later line ' +
-      'of a "Wrap to line 2" message with more than 2 lines. Has no effect once already at ' +
-      'the last line, or on a message with 2 or fewer lines.',
+    'tooltip': 'Moves the currently shown message down by one or two lines (your choice above), ' +
+      'revealing a later line of a message with more than 2 lines - works whether or not ' +
+      '"Wrap to line 2" is on for it. Never moves past the last line, even if that means ' +
+      'moving by less than the chosen amount - and has no effect at all on a message with ' +
+      '2 or fewer lines.',
   },
 ]);
 

--- a/src/blocks/text-strings.js
+++ b/src/blocks/text-strings.js
@@ -13,6 +13,21 @@ import {useConfigurationStorage, useTextStringsStorage} from '../hooks/project';
 // storage - see encodeTextMessage in generators/bbasic/text-minikernel.js).
 export const TEXT_MESSAGE_LENGTH = 12;
 
+// A hard per-card cap on raw typed length (before word-wrap/justify), not
+// just a recommendation - the Text Minikernel's own static "data text_strings"
+// table (see getStaticMessageLayout in generators/bbasic/text-minikernel-
+// layout.js) packs every card's own row offset into a single BYTE (0-255)
+// throughout the generator/asm chain, so the table as a whole can never
+// exceed 256 bytes - a real assembler failure ("Value must be <$100") once
+// it does, confirmed directly against a real project. 240 characters (20
+// wrapped rows of TEXT_MESSAGE_LENGTH each = 240 bytes) leaves the 12-byte
+// reserved guard row still comfortably inside that 256-byte ceiling for a
+// SINGLE card at this cap; a project with multiple such maxed-out cards can
+// still overflow the table as a whole (this only bounds one card at a time,
+// not the project's full total), but it turns an unbounded, silently-failing
+// paragraph into a visible, enforced limit instead.
+export const TEXT_CARD_MAX_LENGTH = 240;
+
 // How many of TEXT_MESSAGE_LENGTH's own 12 positions a project actually
 // wants to USE at once - a project-wide, compile-time-only setting (see
 // TextEditor.vue's own dropdown), never runtime-adjustable: letting it

--- a/src/components/TextFontEditor.vue
+++ b/src/components/TextFontEditor.vue
@@ -1,0 +1,444 @@
+<template>
+  <v-card outlined class="text-font-card">
+    <div class="text-font-card-header" @click="toggleCollapsed(cardEntry)">
+      <span class="text-font-card-title">Text Minikernel Font</span>
+      <v-btn
+        icon
+        small
+        :title="isCollapsed(cardEntry) ? 'Expand this card' : 'Collapse this card'"
+        class="text-font-collapse-btn"
+        @click.stop="toggleCollapsed(cardEntry)"
+      >
+        <v-icon>{{ isCollapsed(cardEntry) ? 'mdi-chevron-down' : 'mdi-chevron-up' }}</v-icon>
+      </v-btn>
+    </div>
+    <v-card-text v-if="!isCollapsed(cardEntry)" class="text-font-card-text">
+      <p class="v-messages theme--light v-messages__message">
+        Edit the Text Minikernel's character set below. Each character is a fixed 4x5 pixel shape.
+      </p>
+      <div class="text-font-controls-row">
+        <editor-zoom v-model="zoom" class="text-font-zoom" />
+        <v-switch
+          v-model="showInGamePreview"
+          label="Preview as in-game"
+          title="The kernel actually draws a blank scanline between each row of a glyph's own pixels - toggle this to see glyphs that way instead of as a plain, solid pixel grid. Read-only: switch back to Off to keep editing."
+          hide-details
+          dense
+          class="text-font-preview-switch"
+        />
+      </div>
+      <p v-if="!ready" class="v-messages theme--light v-messages__message">Loading default glyphs...</p>
+      <template v-else>
+        <!-- Only shown once the Text tab's own "Show a blinking scroll
+             cursor" switch is on (enableTextScrollCursor) - this shape has
+             nothing to do with the 51 real glyphs below it at all (it's
+             never part of the indexed text_data table - see
+             TEXT_CURSOR_WIDTH's own comment in utils/text-font.js), so it's
+             kept visually and structurally separate rather than folded into
+             .glyph-list as a 52nd entry. -->
+        <div v-if="enableTextScrollCursor" class="cursor-glyph-section">
+          <div
+            class="glyph"
+            :style="{width: cursorGlyphWidth}"
+          >
+            <div class="glyph-label">Cursor</div>
+            <div class="glyph-editor">
+              <pixel-editor
+                v-if="!showInGamePreview"
+                :key="resetToken"
+                :width="TEXT_CURSOR_WIDTH"
+                :height="TEXT_CURSOR_HEIGHT"
+                :aspectRatio="PIXEL_ASPECT"
+                v-model="state.cursor"
+                fgColor="#f2691e"
+                :showClearButton="true"
+                name="text-font-cursor"
+                :allowChangingHeight="false"
+                @input="handleChange"
+              />
+              <!-- Same read-only, blank-scanline-interlaced preview as a
+                   real glyph's own (see interlacedPreviewRows below) - the
+                   cursor's own shape is drawn the exact same way, one
+                   scanline per row with a blank one between (see
+                   buildTextScrollCursorOverride in utils/text-font.js). -->
+              <v-card v-else outlined class="glyph-preview-card">
+                <v-card-text>
+                  <div class="glyph-preview-grid">
+                    <div
+                      v-for="(row, rowIndex) in interlacedPreviewRows(state.cursor)"
+                      :key="rowIndex"
+                      class="glyph-preview-row"
+                    >
+                      <div
+                        v-for="(pixel, colIndex) in row"
+                        :key="colIndex"
+                        class="glyph-preview-cell"
+                        :style="{backgroundColor: pixel ? '#f2691e' : '#000'}"
+                      />
+                    </div>
+                  </div>
+                </v-card-text>
+              </v-card>
+            </div>
+          </div>
+        </div>
+        <div class="glyph-list">
+          <div
+            class="glyph"
+            :style="{width: glyphWidth}"
+            v-for="(glyph, index) in state.glyphs"
+            :key="index"
+          >
+            <div class="glyph-label">{{ glyphLabel(TEXT_GLYPH_ORDER[index].char) }}</div>
+            <div class="glyph-editor">
+              <pixel-editor
+                v-if="!showInGamePreview"
+                :key="resetToken"
+                :width="TEXT_GLYPH_WIDTH"
+                :height="TEXT_GLYPH_HEIGHT"
+                :aspectRatio="PIXEL_ASPECT"
+                v-model="state.glyphs[index]"
+                fgColor="#f2691e"
+                :showClearButton="true"
+                :name="'text-font-glyph-' + index"
+                :allowChangingHeight="false"
+                @input="handleChange"
+              >
+                <template v-slot:badge>
+                  <div
+                    class="glyph-id-badge"
+                    title="This glyph's index (0-50) - its byte offset into the compiled glyph table is this number times 5."
+                  >ID:{{ index }}</div>
+                </template>
+              </pixel-editor>
+              <!-- Read-only in-game preview - a blank scanline drawn between
+                   each real pixel row (see interlacedPreviewRows below), not
+                   a live PixelEditor: there's no real pixel data ON those
+                   blank rows to edit at all, so this is a plain, non-
+                   interactive rendering rather than a second editable grid a
+                   stray click could confusingly "draw" on. -->
+              <v-card v-else outlined class="glyph-preview-card">
+                <v-card-text>
+                  <div
+                    class="glyph-id-badge"
+                    title="This glyph's index (0-50) - its byte offset into the compiled glyph table is this number times 5."
+                  >ID:{{ index }}</div>
+                  <div class="glyph-preview-grid">
+                    <div
+                      v-for="(row, rowIndex) in interlacedPreviewRows(glyph)"
+                      :key="rowIndex"
+                      class="glyph-preview-row"
+                    >
+                      <div
+                        v-for="(pixel, colIndex) in row"
+                        :key="colIndex"
+                        class="glyph-preview-cell"
+                        :style="{backgroundColor: pixel ? '#f2691e' : '#000'}"
+                      />
+                    </div>
+                  </div>
+                </v-card-text>
+              </v-card>
+            </div>
+          </div>
+        </div>
+        <v-btn class="reset-button" color="secondary" @click="handleReset">
+          <v-icon>mdi-restore</v-icon>
+          <div>Reset to default glyphs</div>
+        </v-btn>
+      </template>
+    </v-card-text>
+  </v-card>
+</template>
+<script>
+import {computed, defineComponent, onMounted, ref} from '@vue/composition-api';
+
+import EditorZoom from './EditorZoom.vue';
+import PixelEditor from './PixelEditor.vue';
+import {useCollapsedIds} from '../hooks/collapse';
+import {useConfigurationStorage, useTextFontStorage} from '../hooks/project';
+import {useEditorZoom} from '../hooks/zoom';
+import {
+  TEXT_GLYPH_ORDER,
+  TEXT_GLYPH_WIDTH,
+  TEXT_GLYPH_HEIGHT,
+  TEXT_CURSOR_WIDTH,
+  TEXT_CURSOR_HEIGHT,
+  getDefaultTextFont,
+  processTextFontDefaults,
+  processCursorGlyphDefaults,
+  DEFAULT_TEXT_CURSOR,
+} from '../utils/text-font';
+
+// Same reasoning as ScoreFontEditor.vue's own PIXEL_ASPECT - these glyphs are
+// drawn with player graphics too (one color clock per pixel bit, stretched
+// 2:1 by the screen itself), regardless of being only 4 bits wide instead of
+// 8.
+const PIXEL_ASPECT = 2;
+
+// Width of one glyph editor at 100% zoom - narrower than ScoreFontEditor's
+// own DIGIT_BASE_WIDTH (120px for an 8-wide digit), since these glyphs are
+// only 4 pixels wide.
+const GLYPH_BASE_WIDTH = 70;
+
+// One blank scanline between every real pixel row (see text12b.asm's own
+// drawtextrow - each "Text line N/5" section draws a row's own GRP0/GRP1
+// bytes once, then a SECOND WSYNC'd scanline right after resets COLUP0/
+// COLUP1 to textbkcolor before the next row's own bytes are ready), so a
+// glyph's real on-screen height is 2 scanlines per pixel row, not 1 - the
+// second one always blank. Purely a preview concern (see interlacedPreviewRows
+// below) - the stored/edited pixel matrix itself (state.glyphs) never
+// changes shape over this; it's still exactly TEXT_GLYPH_HEIGHT rows.
+const buildBlankRow = () => new Array(TEXT_GLYPH_WIDTH).fill(0);
+
+// A single fixed pseudo-entry id for useCollapsedIds (hooks/collapse.js) -
+// that hook is built around a LIST of entries each with their own id (see
+// TextEditor.vue's own per-message cards), but works just as well for
+// remembering one single card's own collapsed state, keyed under its own
+// dedicated tab name ('text-font-card', passed to useCollapsedIds below) so
+// it can never collide with an actual text message's own id.
+const CARD_ENTRY = {id: 'glyphs'};
+
+export default defineComponent({
+  components: {EditorZoom, PixelEditor},
+  setup() {
+    const textFontStorage = useTextFontStorage();
+    const configurationStorage = useConfigurationStorage();
+    const zoom = useEditorZoom('textfont');
+    const glyphWidth = computed(() => `${Math.round(GLYPH_BASE_WIDTH * zoom.value)}px`);
+    // Same width, same per-pixel size as a real glyph tile - the cursor is
+    // TEXT_CURSOR_WIDTH (4) pixels wide, identical to TEXT_GLYPH_WIDTH.
+    const cursorGlyphWidth = computed(() => `${Math.round(GLYPH_BASE_WIDTH * zoom.value)}px`);
+    const {isCollapsed, toggleCollapsed} = useCollapsedIds('text-font-card');
+
+    // Whether the Text tab's own "Show a blinking scroll cursor" switch is
+    // on - read directly (not passed as a prop) since nothing else about
+    // this component depends on a parent already knowing/passing it down,
+    // same reasoning textBkColor's own read in TextEditor.vue already
+    // establishes for other Configuration-storage-backed Text Minikernel
+    // settings.
+    const enableTextScrollCursor = computed(() => {
+      try {
+        return !!(configurationStorage.value || {}).enableTextScrollCursor;
+      } catch (e) {
+        console.error('Error loading configuration from local storage', e);
+        return false;
+      }
+    });
+
+    // Plain local view state, not persisted - same reasoning as
+    // selectedCardId in TextEditor.vue's own setup(): nothing here should
+    // round-trip through a saved project.
+    const showInGamePreview = ref(false);
+    // Inserts a blank row (buildBlankRow) strictly BETWEEN each of the
+    // glyph's own real pixel rows (see buildBlankRow's own comment for why) -
+    // N real rows become N*2-1 total, never a leading or trailing blank one.
+    const interlacedPreviewRows = (glyphRows) => glyphRows
+        .flatMap((row, i) => (i === glyphRows.length - 1 ? [row] : [row, buildBlankRow()]));
+
+    // getDefaultTextFont() parses the real vendored text12b.asm (an async
+    // fetch, cached after the first call) rather than a hand-transcribed
+    // constant - see its own comment in utils/text-font.js. state/handleReset
+    // below simply have nothing to fall back to until this resolves, same as
+    // any other "first paint waits on an async default" case in this app.
+    const defaultGlyphs = ref(null);
+    const ready = computed(() => !!defaultGlyphs.value);
+    onMounted(async () => {
+      try {
+        defaultGlyphs.value = await getDefaultTextFont();
+      } catch (e) {
+        console.error('Failed to load the Text Minikernel\'s default glyphs', e);
+      }
+    });
+
+    const state = computed({
+      get() {
+        if (!defaultGlyphs.value) return {glyphs: [], cursor: DEFAULT_TEXT_CURSOR};
+        try {
+          return {
+            ...processTextFontDefaults(textFontStorage, defaultGlyphs.value),
+            cursor: processCursorGlyphDefaults(textFontStorage),
+          };
+        } catch (e) {
+          console.error('Error loading the text font from local storage', e);
+          return {glyphs: defaultGlyphs.value, cursor: DEFAULT_TEXT_CURSOR};
+        }
+      },
+
+      set(newState) {
+        textFontStorage.value = newState;
+      },
+    });
+
+    // The pixel editor mutates its matrix in place, so the whole object is
+    // reassigned to push it back into storage - same pattern as
+    // ScoreFontEditor.vue's own handleChange.
+    const handleChange = () => {
+      state.value = state.value;
+    };
+
+    // The space glyph's own char (' ') renders as empty, collapsed text -
+    // without a visible stand-in, its label div has no content at all,
+    // leaving it (and it alone) shorter than every other glyph's own
+    // labeled card, so its whole card sits higher than the rest of its row
+    // instead of lining up with them.
+    const glyphLabel = (char) => (char === ' ' ? '(space)' : char);
+
+    // Same "PixelEditor only reads its value prop once, on mount" reset
+    // trick as ScoreFontEditor.vue's own resetToken.
+    const resetToken = ref(0);
+    const handleReset = () => {
+      state.value = {
+        glyphs: defaultGlyphs.value.map((rows) => rows.map((row) => row.slice())),
+        cursor: DEFAULT_TEXT_CURSOR.map((row) => row.slice()),
+      };
+      resetToken.value++;
+    };
+
+    return {
+      state, handleChange, handleReset, ready, resetToken, glyphLabel,
+      zoom, glyphWidth, cursorGlyphWidth, isCollapsed, toggleCollapsed, cardEntry: CARD_ENTRY,
+      showInGamePreview, interlacedPreviewRows, enableTextScrollCursor,
+      TEXT_GLYPH_ORDER, TEXT_GLYPH_WIDTH, TEXT_GLYPH_HEIGHT, TEXT_CURSOR_WIDTH, TEXT_CURSOR_HEIGHT, PIXEL_ASPECT,
+    };
+  },
+});
+</script>
+<style scoped>
+.text-font-card {
+  margin-bottom: 16px;
+}
+
+.text-font-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 8px 12px 16px;
+  cursor: pointer;
+}
+
+.text-font-card-title {
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+/* Vuetify's own ".v-card__title + .v-card__text" rule zeroes this same
+   padding automatically when a real v-card-title comes right before it (see
+   TextEditor.vue's own top-level card, confirmed directly: 0px there) - it
+   never applies here since .text-font-card-header is a plain div, not an
+   actual v-card-title, so this description paragraph sat a further 16px
+   below the header than the Text tab's own description sits below ITS
+   title. Zeroed here by hand to match that same spacing exactly. */
+.text-font-card-text {
+  padding-top: 0;
+}
+
+.text-font-controls-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.text-font-zoom {
+  margin-bottom: 0;
+}
+
+/* Same margin-top/padding-top override as TextEditor.vue's own
+   .text-columns-switch - Vuetify's own selection-control margin-top (meant
+   for stacking below other fields) otherwise pushes this out of line with
+   the zoom control sharing this same row. */
+.text-font-preview-switch {
+  flex: 0 0 auto;
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+}
+
+.cursor-glyph-section {
+  margin-bottom: 20px;
+}
+
+/* Width is set inline (cursorGlyphWidth) from the zoom factor. */
+
+.glyph-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  /* Every card in a row should start at the same height regardless of which
+     row it's actually in (see .glyph-label's own min-height comment right
+     below) - flex's default "stretch" would instead make every card in a
+     row match the row's TALLEST card, which isn't what's wanted here either. */
+  align-items: flex-start;
+}
+
+/* Width is set inline from the zoom factor. */
+
+/* min-height (rather than relying on the text itself) keeps every card in a
+   row starting at the same height even when a label's own text is empty -
+   the space glyph's own char is a literal " ", which the browser collapses
+   to nothing visible, leaving that one card shorter (and so higher, given
+   align-items: flex-start above) than its neighbors sharing the same row.
+   glyphLabel() (see the script below) already substitutes "(space)" text
+   for that one specific case, but this stays as a general safeguard rather
+   than relying on every possible label always having real visible text. */
+.glyph-label {
+  min-height: 1.2em;
+  font-weight: bold;
+  text-align: center;
+}
+
+.glyph-editor {
+  position: relative;
+}
+
+/* Same placement/style as PlayerEditor.vue's own .frame-number-badge -
+   plain flow (not overlaid on the card border), via the "badge" slot
+   PixelEditor.vue exposes for exactly this, so it sits INSIDE the pixel
+   editor's own rendered card, pushing the canvas down naturally rather than
+   floating on top of it (which made it hard to read whenever the top row of
+   pixels happened to be drawn in a similar color). This glyph's plain
+   0-based index lets one be pointed out unambiguously even for a character
+   (e.g. two easily-confused punctuation marks) that's hard to describe
+   otherwise. */
+.glyph-id-badge {
+  text-align: left;
+  font-size: 0.7rem;
+  font-family: monospace;
+  opacity: 0.6;
+  /* Pulls it up out of v-card-text's default 16px top padding, same reason
+     as .frame-number-badge's own identical margin-top. */
+  margin-top: -8px;
+}
+
+/* Matches PixelEditor.vue's own outlined v-card shape/width - kept a plain
+   read-only rendering rather than a second PixelEditor instance (see the
+   template's own comment on why), so its sizing has to be replicated by
+   hand instead of coming from that component's own CSS. */
+.glyph-preview-card {
+  width: 100%;
+}
+
+.glyph-preview-grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.glyph-preview-row {
+  display: flex;
+}
+
+/* aspect-ratio 2/1 matches PIXEL_ASPECT (edit mode's own pixel cells are
+   twice as wide as tall, for the same "one screen pixel is 2:1" reason - see
+   PIXEL_ASPECT's own comment) - a blank interlaced row (see
+   interlacedPreviewRows) is a real scanline too, so it keeps the exact same
+   per-row height as a genuine pixel row rather than reading as a thin
+   spacer. */
+.glyph-preview-cell {
+  flex: 1;
+  aspect-ratio: 2 / 1;
+}
+
+.reset-button {
+  margin-top: 24px;
+}
+</style>

--- a/src/components/blockly-toolbox.xml.hbs
+++ b/src/components/blockly-toolbox.xml.hbs
@@ -113,6 +113,25 @@
                 </shadow>
             </value>
         </block>
+        <block type="sprite_player_fade_to">
+            <field name="VAR">player0realcolor</field>
+            <value name="VALUE">
+                <shadow type="color_get">
+                    <field name="COLOR">212</field>
+                </shadow>
+            </value>
+            <value name="FRAMES">
+                <shadow type="math_number">
+                    <field name="NUM">30</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="sprite_player_fade_finished">
+            <field name="VAR">player0realcolor</field>
+        </block>
+        <block type="sprite_player_fade_active">
+            <field name="VAR">player0realcolor</field>
+        </block>
 
         <block type="sprite_player1_get"></block>
         <block type="sprite_player1_set">
@@ -162,6 +181,25 @@
                     <field name="COLOR">250</field>
                 </shadow>
             </value>
+        </block>
+        <block type="sprite_player_fade_to">
+            <field name="VAR">player1realcolor</field>
+            <value name="VALUE">
+                <shadow type="color_get">
+                    <field name="COLOR">250</field>
+                </shadow>
+            </value>
+            <value name="FRAMES">
+                <shadow type="math_number">
+                    <field name="NUM">30</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="sprite_player_fade_finished">
+            <field name="VAR">player1realcolor</field>
+        </block>
+        <block type="sprite_player_fade_active">
+            <field name="VAR">player1realcolor</field>
         </block>
 
         <block type="sprite_missile0_get"></block>
@@ -700,6 +738,20 @@
                 </shadow>
             </value>
         </block>
+        <block type="text_minikernel_set_cursor_color">
+            <value name="VALUE">
+                <shadow type="color_get">
+                    <field name="COLOR">15</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="text_minikernel_set_end_icon_color">
+            <value name="VALUE">
+                <shadow type="color_get">
+                    <field name="COLOR">15</field>
+                </shadow>
+            </value>
+        </block>
         <block type="text_minikernel_fade_to">
             <value name="VALUE">
                 <shadow type="color_get">
@@ -715,6 +767,7 @@
         <block type="text_minikernel_fade_finished"></block>
         <block type="text_minikernel_scroll_control"></block>
         <block type="text_minikernel_scroll_at"></block>
+        <block type="text_minikernel_end_icon_visible"></block>
         <block type="text_minikernel_line_scroll_up"></block>
         <block type="text_minikernel_line_scroll_down"></block>
         <block type="text_minikernel_clear"></block>

--- a/src/generators/bbasic.js
+++ b/src/generators/bbasic.js
@@ -19,7 +19,7 @@ import {useBackgroundsStorage, useConfigurationStorage, useDataTablesStorage, us
 import {getRelocationBanks} from '../hooks/relocation-banks';
 import {DEFAULT_ROW_COLOR, processBackgroundStorageDefaults,
   backgroundFadeTimerVarName, backgroundFadePaceVarName, backgroundFadeTargetVarName,
-  fadeFlagsVarName, backgroundGetPixelXVarName, backgroundGetPixelYVarName,
+  fadeFlagsVarName, FADE_FLAGS_REGISTER_GROUPS, backgroundGetPixelXVarName, backgroundGetPixelYVarName,
   resolveBackgroundFadeFinishedWatches, hasBackgroundFadeActiveChecks} from '../blocks/background';
 import {functionCallDiscardVarName, functionCallArgVarName, functionParamVarName,
   MAX_FUNCTION_ARGS} from '../blocks/function';
@@ -49,7 +49,8 @@ import {resolveProjectMusic, MUSIC_PLAY_RESET_NAME, MUSIC_PLAY_BY_ID_NAME,
   registerMusicPlayResetSubroutine, resolveMusicEventFlags,
   resolveNotePlayedInstruments, reserveMusicDevVars} from './bbasic/music';
 import {reserveTextScrollDevVars, generateTextScrollAdvance, generateTextOffsetTables} from './bbasic/text-scroll';
-import {generateTextStaticOffsetTables, textLinesBaseVarName, textLinesMaxVarName} from './bbasic/text-minikernel';
+import {generateTextStaticOffsetTables, textLinesBaseVarName, textLinesMaxVarName,
+  textRow2ColorVarName, textScrollCursorColorVarName, textEndIconColorVarName} from './bbasic/text-minikernel';
 
 const handlebarsTemplate = Handlebars.compile(templateText);
 
@@ -397,9 +398,30 @@ Blockly.BBasic.init = function(workspace) {
   // text-minikernel.js) - a project using only plain "Show text" blocks
   // (even ones with "Wrap to line 2" on) has no use for either, since
   // nothing ever reads them without one of these two blocks present.
-  const TEXT_LINE_SCROLL_BLOCK_TYPES = ['text_minikernel_line_scroll_up', 'text_minikernel_line_scroll_down'];
+  const TEXT_LINE_SCROLL_BLOCK_TYPES = ['text_minikernel_line_scroll_up', 'text_minikernel_line_scroll_down',
+    'text_minikernel_end_icon_visible'];
+  // The "more below" scroll cursor (see text12b.asm's own "textScrollCursor"
+  // ifconst block) reads _textLinesMax/TextRow2Active directly in
+  // hand-written asm, for WHATEVER message is currently shown - not just
+  // ones a "Scroll text lines" block happens to act on - so it needs this
+  // same tracking kept live from every "Show text" call too, same as if
+  // such a block existed (see needsTextRow2ActiveDim's own comment in
+  // generators/bbasic/text-minikernel.js for the TextRow2Active half of
+  // this).
+  // Whether any "Text: set color" block actually targets row 2 (its ROW
+  // dropdown set to "2" or "both") - unlike isTextRow2Used() (which checks
+  // Text tab data), this is a real block-field pre-scan, since row 1 is
+  // that dropdown's own default and the common case doesn't touch row 2's
+  // var at all. Used below to reserve _textRow2Color only when something
+  // could actually write to it - a project using only row-1 color blocks
+  // (or none at all) pays nothing for it.
+  this.textRow2ColorBlockUsed = workspace.getAllBlocks(false).some((block) =>
+    block.type === 'text_minikernel_set_color' && block.getFieldValue('ROW') === '2');
+  const textScrollCursorConfig = (useConfigurationStorage().value || {});
+  this.textScrollCursorUsed = !!textScrollCursorConfig.enableTextScrollCursor;
   this.textLineScrollUsed =
-    workspace.getAllBlocks(false).some((block) => TEXT_LINE_SCROLL_BLOCK_TYPES.includes(block.type));
+    workspace.getAllBlocks(false).some((block) => TEXT_LINE_SCROLL_BLOCK_TYPES.includes(block.type)) ||
+    this.textScrollCursorUsed;
 
   // Same early block-type pre-scan reasoning as textScrollUsed just above,
   // for "Show text with ID"/"Scroll text ID"'s own captured-argument var
@@ -1109,6 +1131,24 @@ Blockly.BBasic.init = function(workspace) {
         'currently shown message: highest TextIndex "Scroll text lines down" can reach');
   }
 
+  // Same bucket again, for row 2's own color (settable via the merged
+  // "Text: set color" block's own ROW dropdown - row 1 is the default, so
+  // this only needs reserving when something actually targets row 2, see
+  // textRow2ColorBlockUsed's own pre-scan above) and the scroll cursor's own
+  // color ("Text: set scroll cursor color") - see textRow2ColorVarName/
+  // textScrollCursorColorVarName's own comment in generators/bbasic/
+  // text-minikernel.js for why these need real dev vars, unlike TextColor.
+  if (this.isTextRow2Used() || this.textRow2ColorBlockUsed) {
+    reserveDevVar(textRow2ColorVarName(), undefined,
+        'wrapped messages: row 2\'s own color ("Text: set color" block\'s ROW dropdown)');
+  }
+  if (this.textScrollCursorUsed) {
+    reserveDevVar(textScrollCursorColorVarName(), undefined,
+        'the blinking scroll cursor\'s own color ("Text: set scroll cursor color" block)');
+    reserveDevVar(textEndIconColorVarName(), undefined,
+        'the "end of message" icon\'s own color ("Text: set end icon color" block)');
+  }
+
   // Same bucket again, for the ROM noise feature's own per-player state (see
   // reserveRomNoiseDevVars' own comment in generators/bbasic/sprites.js) - a
   // no-op unless romNoiseUsedFor's own early pre-scan (above) found it used.
@@ -1257,15 +1297,16 @@ Blockly.BBasic.init = function(workspace) {
   // on the instance (not a local) so generateBackgroundFadeChecks, which
   // runs later during the final generation pass, knows which registers to
   // emit a per-frame check for.
-  // score_fade_to/text_minikernel_fade_to (Score/Text tab equivalents of
-  // background_fade_to - see generators/bbasic/score.js and
-  // generators/bbasic/text-minikernel.js) share this exact same mechanism,
-  // just always targeting their own fixed register rather than offering a
-  // VAR dropdown (there's only ever one possible score color or text color
-  // register, unlike background/playfield).
+  // score_fade_to/text_minikernel_fade_to/sprite_player_fade_to (Score/Text/
+  // Player tab equivalents of background_fade_to - see generators/bbasic/
+  // score.js, generators/bbasic/text-minikernel.js, and generators/bbasic/
+  // sprites.js) share this exact same mechanism, just always targeting
+  // their own fixed register (score_fade_to/text_minikernel_fade_to) or a
+  // Player 0/1-only dropdown (sprite_player_fade_to) rather than offering
+  // background_fade_to's own Background/Playfield choice.
   this.backgroundFadeVarsUsed = new Set();
   workspace.getAllBlocks(false).forEach((block) => {
-    if (block.type === 'background_fade_to') {
+    if (block.type === 'background_fade_to' || block.type === 'sprite_player_fade_to') {
       this.backgroundFadeVarsUsed.add(block.getFieldValue('VAR'));
     } else if (block.type === 'score_fade_to') {
       this.backgroundFadeVarsUsed.add('scorecolor');
@@ -1278,16 +1319,26 @@ Blockly.BBasic.init = function(workspace) {
     reserveDevVar(backgroundFadePaceVarName(rawVar), undefined, 'this register\'s fade: frames per step');
     reserveDevVar(backgroundFadeTargetVarName(rawVar), undefined, 'this register\'s fade: color it\'s fading toward');
   });
-  // One shared byte for every background_fade_finished watch bit AND every
-  // background_fade_to "active" bit (see fadeFlagsVarName's own
-  // comment) - reserved as soon as any of the three is needed, since the
-  // "active" bits alone (with no finished watch and, via
-  // background_fade_active, not even a matching fade_to block on that same
-  // register) still need this byte to exist for the read to be valid.
-  if (this.backgroundFadeFinishedWatches.size || this.backgroundFadeVarsUsed.size ||
-      hasBackgroundFadeActiveChecks(workspace)) {
-    reserveDevVar(fadeFlagsVarName(), undefined, 'shared active/finished bit-flags byte for every fadeable register');
-  }
+  // One shared byte per group of up to 4 fadeable registers (see
+  // FADE_FLAGS_REGISTER_GROUPS' own comment in blocks/background.js - a 5th+
+  // register, like sprite_player_fade_to's own player0realcolor/
+  // player1realcolor, gets its own second byte, since the first one's 8 bits
+  // are already spoken for by Background/Playfield/Score/Text) - reserved
+  // per GROUP as soon as any of that group's own registers needs it (a
+  // "finished" watch, a fade_to trigger, or an "is active" check), since the
+  // "active" bits alone (with no finished watch and, via background_fade_
+  // active/sprite_player_fade_active, not even a matching fade_to block on
+  // that same register) still need their own byte to exist for the read to
+  // be valid.
+  const fadeActiveCheckVars = hasBackgroundFadeActiveChecks(workspace);
+  const allFadeVarsNeedingAByte = new Set([
+    ...this.backgroundFadeFinishedWatches, ...this.backgroundFadeVarsUsed, ...fadeActiveCheckVars,
+  ]);
+  FADE_FLAGS_REGISTER_GROUPS.forEach((group) => {
+    if (!group.some((rawVar) => allFadeVarsNeedingAByte.has(rawVar))) return;
+    reserveDevVar(fadeFlagsVarName(group[0]), undefined,
+        'shared active/finished bit-flags byte for this group of fadeable registers');
+  });
 
   // Add user variables, but only ones that are being used. Their own FINAL
   // routed names are tracked separately (userVarNames) so the ROM capacity
@@ -2927,6 +2978,15 @@ Blockly.BBasic.generateConfiguration = function() {
   // this const at all, so it has no effect (and no conflict) while the Text
   // Minikernel is active.
   const scoreFadeConfigurationCode = config.enableScoreFade ? 'const scorefade = 1' : '';
+  // "scorepaddinglines" (the Score tab's own "Add score padding" dropdown,
+  // config.scorePaddingLines, 0/1/2) - text12a.asm's own "if
+  // scorepaddinglines >= N" checks (right after the score digit loop) read
+  // this directly. Emitted unconditionally (defaulting to 0) since that
+  // file's own compile-time "if" expression needs the symbol to exist at
+  // all, unlike an ifconst check - text12a.asm has its own "ifnconst
+  // scorepaddinglines" fallback too, but emitting it explicitly here keeps
+  // the actual configured value visible in the generated source.
+  const scorePaddingConfigurationCode = `const scorepaddinglines = ${config.scorePaddingLines || 0}`;
   // The bundled compiler ignores this and gets its digits swapped in directly
   // instead, but it keeps the generated source correct for real batari Basic.
   // Custom digits live in the compiler's include, so there is no directive that
@@ -3050,6 +3110,7 @@ Blockly.BBasic.generateConfiguration = function() {
     kernelOptionsConfigurationCode,
     scoreConfigurationCode,
     scoreFadeConfigurationCode,
+    scorePaddingConfigurationCode,
     scoreFontConfigurationCode,
     textFontConfigurationCode,
     scoreFontExtraGlyphsConfigurationCode,

--- a/src/generators/bbasic/background.js
+++ b/src/generators/bbasic/background.js
@@ -60,7 +60,10 @@ export const backgroundGetPixelDevVarsNeeded = (block) =>
 // scorecolor/TextColor share this same check-generating function alongside
 // COLUBK/COLUPF, or two registers' own labels would collide into the exact
 // same names and only the first would ever compile correctly.
-const FADE_LABEL_TAG_BY_VAR = {COLUBK: 'bg', COLUPF: 'pf', scorecolor: 'score', TextColor: 'text'};
+const FADE_LABEL_TAG_BY_VAR = {
+  COLUBK: 'bg', COLUPF: 'pf', scorecolor: 'score', TextColor: 'text',
+  player0realcolor: 'p0', player1realcolor: 'p1',
+};
 
 export default (Blockly) => {
   // A compile-time constant, not runtime state - the playfield's vertical
@@ -233,7 +236,7 @@ export default (Blockly) => {
     const timerVar = resolveVar(backgroundFadeTimerVarName(rawVar));
     const paceVar = resolveVar(backgroundFadePaceVarName(rawVar));
     const targetVar = resolveVar(backgroundFadeTargetVarName(rawVar));
-    const activeBit = `${resolveVar(fadeFlagsVarName())}{${fadeActiveBit(rawVar)}}`;
+    const activeBit = `${resolveVar(fadeFlagsVarName(rawVar))}{${fadeActiveBit(rawVar)}}`;
     // frames/FADE_STEPS is still a genuine runtime division (frames isn't
     // known at compile time) - needs the shared div8 routine UNLESS the
     // divisor is a compile-time constant power of 2, in which case the
@@ -500,34 +503,45 @@ export default (Blockly) => {
       // color's own comment above) since the score/text drawing routines
       // overwrite the real register every frame - scorecolor/TextColor have
       // no such override, so the real variable doubles as its own shadow.
-      const isShadowedRegister = rawVar === 'COLUPF' || rawVar === 'COLUBK';
+      // player0realcolor/player1realcolor have no separate shadow ALIAS
+      // either (nothing renames them the way COLUBK/COLUPF rename to
+      // backgroundrealcolor/playfieldrealcolor), but - unlike scorecolor/
+      // TextColor - they're still app-internal dev vars needing nameDB_
+      // resolution (sprite_${name}_get/set already resolve this same VAR
+      // through nameDB_/VARIABLE_CATEGORY_NAME - see generators/bbasic/
+      // sprites.js), so they're grouped with COLUBK/COLUPF below, not
+      // scorecolor/TextColor.
+      const needsNameDbResolution = rawVar === 'COLUPF' || rawVar === 'COLUBK' ||
+        rawVar === 'player0realcolor' || rawVar === 'player1realcolor';
       const targetShadowVar = rawVar === 'COLUPF' ? 'playfieldrealcolor' :
         rawVar === 'COLUBK' ? 'backgroundrealcolor' : rawVar;
       // scorecolor/TextColor are real batari Basic identifiers already
       // (score.js's own score_color_get/set and text-minikernel.js's own
       // TextColor blocks both reference them as plain literals, never
-      // through nameDB_) - only COLUBK/COLUPF's own shadow vars are
-      // app-internal dev vars that actually need letter resolution.
-      const colorVarName = isShadowedRegister ?
+      // through nameDB_) - only COLUBK/COLUPF's own shadow vars and
+      // player0realcolor/player1realcolor are app-internal dev vars that
+      // actually need letter resolution.
+      const colorVarName = needsNameDbResolution ?
         Blockly.BBasic.nameDB_.getName(targetShadowVar, Blockly.VARIABLE_CATEGORY_NAME) : targetShadowVar;
       const timerVar = resolveVar(backgroundFadeTimerVarName(rawVar));
       const paceVar = resolveVar(backgroundFadePaceVarName(rawVar));
       const targetVar = resolveVar(backgroundFadeTargetVarName(rawVar));
       const tag = FADE_LABEL_TAG_BY_VAR[rawVar] || rawVar;
 
-      // Every register (background/playfield AND score/text) routes through
-      // a hand-written asm version instead (see buildFadeCheckAsm's own
-      // comment) - real cycle savings over the bB if/goto chain this used to
-      // be. buildFadeCheckAsm itself doesn't care whether colorVarName came
-      // from a resolved dev var (COLUBK/COLUPF's own shadow vars) or a bare
-      // literal identifier (scorecolor/TextColor) - either way it's already
-      // just a plain string by the time it gets here.
+      // Every register (background/playfield, score/text, AND player) routes
+      // through a hand-written asm version instead (see buildFadeCheckAsm's
+      // own comment) - real cycle savings over the bB if/goto chain this
+      // used to be. buildFadeCheckAsm itself doesn't care whether
+      // colorVarName came from a resolved dev var (COLUBK/COLUPF/player0/
+      // player1's own shadow vars) or a bare literal identifier (scorecolor/
+      // TextColor) - either way it's already just a plain string by the time
+      // it gets here.
       return buildFadeCheckAsm({
         colorVar: colorVarName,
         targetVar,
         timerVar,
         paceVar,
-        flagsVar: resolveVar(fadeFlagsVarName()),
+        flagsVar: resolveVar(fadeFlagsVarName(rawVar)),
         activeBit: fadeActiveBit(rawVar),
         finishedBit: backgroundFadeFinishedBit(rawVar),
         tag,
@@ -580,7 +594,7 @@ export default (Blockly) => {
     // resolveMusicEventFlags is the shipped instance of the exact same
     // handling).
     if (!watches.has(backgroundFadeWatchKey(rawVar))) return '';
-    const flagBit = `${resolveVar(fadeFlagsVarName())}{${backgroundFadeFinishedBit(rawVar)}}`;
+    const flagBit = `${resolveVar(fadeFlagsVarName(rawVar))}{${backgroundFadeFinishedBit(rawVar)}}`;
     const blockNumber = Blockly.BBasic.blockNumbers.next();
     const labelEnd = `_bgfadefin_${blockNumber}_end`;
     return '\n' +
@@ -605,7 +619,7 @@ export default (Blockly) => {
   // the bit is always safe to read here even if it will only ever hold 0.
   Blockly.BBasic[`background_fade_active`] = function(block) {
     const rawVar = block.getFieldValue('VAR');
-    const activeBit = `${resolveVar(fadeFlagsVarName())}{${fadeActiveBit(rawVar)}}`;
+    const activeBit = `${resolveVar(fadeFlagsVarName(rawVar))}{${fadeActiveBit(rawVar)}}`;
     return [activeBit, Blockly.BBasic.ORDER_ATOMIC];
   };
 

--- a/src/generators/bbasic/sprites.js
+++ b/src/generators/bbasic/sprites.js
@@ -2,6 +2,7 @@
 
 import {playfieldToMatrix} from '../../utils/pixels';
 import {useConfigurationStorage} from '../../hooks/project';
+import {fadeFlagsVarName, fadeActiveBit} from '../../blocks/background';
 
 
 export const DEFAULT_SPRITES={
@@ -1026,5 +1027,36 @@ export default (Blockly) => {
         Blockly.Names.DEVELOPER_VARIABLE_TYPE);
     return `${shadowVar}{2} = ${value}\n` +
         `CTRLPF = ${shadowVar}\n`;
+  };
+
+  // Player 0/1's color fade trigger - same shared mechanism as Background's
+  // own "Fade color to" (see emitColorFadeTrigger in generators/bbasic/
+  // background.js), just targeting player0realcolor/player1realcolor
+  // (whichever the VAR dropdown picked) instead of COLUBK/COLUPF. This is
+  // set up by background.js's own init(), which always runs before this file's
+  // (see the registration order in generators/bbasic.js), so
+  // Blockly.BBasic.emitColorFadeTrigger already exists by the time this runs.
+  Blockly.BBasic['sprite_player_fade_to'] = function(block) {
+    const rawVar = block.getFieldValue('VAR');
+    const color = Blockly.BBasic.valueToCode(block, 'VALUE', Blockly.BBasic.ORDER_NONE) || '0';
+    const frames = Blockly.BBasic.valueToCode(block, 'FRAMES', Blockly.BBasic.ORDER_NONE) || '1';
+    return Blockly.BBasic.emitColorFadeTrigger(rawVar, color, frames);
+  };
+
+  // Player 0/1's own fade-finished watch - same shared mechanism as
+  // Background's own "When ... color has finished fading" (see
+  // emitFadeFinishedWatch in generators/bbasic/background.js).
+  Blockly.BBasic['sprite_player_fade_finished'] = function(block) {
+    return Blockly.BBasic.emitFadeFinishedWatch(block, block.getFieldValue('VAR'));
+  };
+
+  // Plain boolean read of the active bit - same shape as background_fade_
+  // active's own generator (see generators/bbasic/background.js).
+  Blockly.BBasic['sprite_player_fade_active'] = function(block) {
+    const rawVar = block.getFieldValue('VAR');
+    const resolveVar = (canonicalName) =>
+      Blockly.BBasic.nameDB_.getName(canonicalName, Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+    const activeBit = `${resolveVar(fadeFlagsVarName(rawVar))}{${fadeActiveBit(rawVar)}}`;
+    return [activeBit, Blockly.BBasic.ORDER_ATOMIC];
   };
 };

--- a/src/generators/bbasic/text-minikernel-files.js
+++ b/src/generators/bbasic/text-minikernel-files.js
@@ -22,12 +22,29 @@ export const getExtendedScoreGraphics = () => {
   return scoreGraphicsPromise;
 };
 
+// The pristine, unmodified text12b.asm - fetched once and cached, same
+// reasoning as getExtendedScoreGraphics above. Exposed separately (not just
+// folded into getTextMinikernelSiblingFiles below) so utils/text-font.js can
+// fetch this same content on its own: once to parse the built-in glyph
+// shapes for a fresh Text Font Editor (getDefaultTextFont), and again to
+// build a byte-for-byte override splicing the user's own edited glyphs in
+// (buildTextFontOverride) - both need the real pristine bytes as their
+// starting point, the same way score font's own buildScoreFontOverride
+// starts from getPristineScoreGraphics (utils/score-font.js).
+let pristineText12bPromise = null;
+export const getPristineText12b = () => {
+  if (!pristineText12bPromise) {
+    pristineText12bPromise = fetchText('bb19/text-minikernel/text12b.asm');
+  }
+  return pristineText12bPromise;
+};
+
 let filesPromise = null;
 export const getTextMinikernelSiblingFiles = () => {
   if (!filesPromise) {
     filesPromise = Promise.all([
       fetchText('bb19/text-minikernel/text12a.asm'),
-      fetchText('bb19/text-minikernel/text12b.asm'),
+      getPristineText12b(),
       getExtendedScoreGraphics(),
     ]).then(([text12a, text12b, scoreGraphics]) => ({
       'text12a.asm': text12a,

--- a/src/generators/bbasic/text-minikernel-layout.js
+++ b/src/generators/bbasic/text-minikernel-layout.js
@@ -18,41 +18,58 @@ import {TEXT_MESSAGE_LENGTH, listTextStrings, resolveTextMaxDisplayWidth} from '
 // truncation still caps any one line at maxWidth, same as a plain message).
 // Only when the text has NO explicit break at all does this fall back to
 // ordinary word-wrap (breaking at the last space that still fits, or hard
-// at maxWidth if there's no space to break on), producing at most 2 lines -
-// matching a plain, non-wrapping message's own single-row behavior for
-// anything that already fits on one line. Exported (not local to
-// text-minikernel.js) so getStaticMessageLayout below can size each entry
-// by its own real line count, not just "1 or 2".
+// at maxWidth if there's no space to break on) - repeated until the whole
+// remainder fits, so a message needing 3+ lines (revealed via "Scroll text
+// lines up/down", not just "Wrap to line 2"'s own 2-line display) gets a
+// real row per wrapped line instead of everything past the first break
+// getting dumped, unwrapped, into one oversized final line - a real
+// reported gap ("auto line-break works without scrolling, not with it").
+// Exported (not local to text-minikernel.js) so getStaticMessageLayout below
+// can size each entry by its own real line count, not just "1 or 2".
 export const splitMessageLines = (text, maxWidth) => {
   const raw = String(text || '');
   if (raw.includes('\n')) return raw.split('\n').map((line) => line.toUpperCase());
-  const upper = raw.toUpperCase();
-  if (upper.length <= maxWidth) return [upper];
-  const window = upper.slice(0, maxWidth + 1);
-  const lastSpace = window.lastIndexOf(' ');
-  if (lastSpace <= 0) return [upper.slice(0, maxWidth), upper.slice(maxWidth).trimStart()];
-  return [upper.slice(0, lastSpace), upper.slice(lastSpace + 1)];
+  let remaining = raw.toUpperCase();
+  const lines = [];
+  while (remaining.length > maxWidth) {
+    const window = remaining.slice(0, maxWidth + 1);
+    const lastSpace = window.lastIndexOf(' ');
+    if (lastSpace <= 0) {
+      lines.push(remaining.slice(0, maxWidth));
+      remaining = remaining.slice(maxWidth).trimStart();
+    } else {
+      lines.push(remaining.slice(0, lastSpace));
+      remaining = remaining.slice(lastSpace + 1);
+    }
+  }
+  lines.push(remaining);
+  return lines;
 };
 
-// Every Text tab entry's own byte offset (and row count - always 1 for a
-// non-wrapping entry; for a "Wrap to line 2" entry, however many lines its
-// own text actually splits into via splitMessageLines above) within the
-// STATIC region of the "data text_strings" table (see generateTextMinikernel
-// in text-minikernel.js) - position 0 is the reserved blank guard row,
-// always exactly TEXT_MESSAGE_LENGTH bytes. Only the first two of a
-// wrapping entry's own rows are ever drawn at once (see text12b.asm's own
-// "textkernel2ndrow" block, which always reads row 2 from TextIndex+
-// TEXT_MESSAGE_LENGTH, with no separate pointer of its own) - "Scroll text
-// lines up/down" (see generators/bbasic/text-minikernel.js) moves TextIndex
-// by a whole row at a time to bring the rest into view.
+// Every Text tab entry's own byte offset, row count, and "Wrap to line 2"
+// flag within the STATIC region of the "data text_strings" table (see
+// generateTextMinikernel in text-minikernel.js) - position 0 is the reserved
+// blank guard row, always exactly TEXT_MESSAGE_LENGTH bytes. Row count comes
+// from splitMessageLines UNCONDITIONALLY now, regardless of "Wrap to line
+// 2" - a message longer than maxWidth always gets split into real, separate
+// rows (an explicit line break always splits, and even a plain overlong
+// message word-wraps into a second row) rather than silently truncating
+// its overflow the moment "Wrap to line 2" happens to be off. That toggle's
+// own remaining, narrower job (see namedMessageWrapToLine2's own comment in
+// text-minikernel.js) is only "does row 2 draw automatically, alongside row
+// 1, with no scrolling needed" - "Scroll text lines up/down" can reveal a
+// message's 2nd+ rows one at a time either way, moving TextIndex a whole row
+// at a time (only the FIRST row is ever on screen for a non-wrapping entry,
+// same as text12b.asm's own "textkernel2ndrow" block only ever draws row 2
+// from TextIndex+TEXT_MESSAGE_LENGTH when told to).
 export const getStaticMessageLayout = () => {
   const entries = listTextStrings();
   const maxWidth = resolveTextMaxDisplayWidth();
-  const layout = [{offset: 0, lineCount: 1}];
+  const layout = [{offset: 0, lineCount: 1, wrapToLine2: false}];
   let offset = TEXT_MESSAGE_LENGTH;
   entries.forEach(({text, wrapToLine2}) => {
-    const lineCount = wrapToLine2 ? Math.max(1, splitMessageLines(text, maxWidth).length) : 1;
-    layout.push({offset, lineCount});
+    const lineCount = Math.max(1, splitMessageLines(text, maxWidth).length);
+    layout.push({offset, lineCount, wrapToLine2: !!wrapToLine2});
     offset += lineCount * TEXT_MESSAGE_LENGTH;
   });
   return layout;

--- a/src/generators/bbasic/text-minikernel.js
+++ b/src/generators/bbasic/text-minikernel.js
@@ -28,6 +28,28 @@ import {getStaticMessageLayout, staticMessageRegionEnd, splitMessageLines} from 
 export const textLinesBaseVarName = () => '_textLinesBase';
 export const textLinesMaxVarName = () => '_textLinesMax';
 
+// Row 2's own color (settable via the merged "Text: set color" block's own
+// ROW dropdown, text_minikernel_set_color below) and the scroll cursor's own color
+// (via "Text: set scroll cursor color", text_minikernel_set_cursor_color
+// below) - unlike TextColor (a fixed alias onto statusbarlength, a real bB
+// built-in with a spare byte to reuse), there's no equivalent spare built-in
+// for either of these, so each needs a real dev-var-pool slot of its own.
+// Read directly by hand-written asm (text12b.asm's own "textkernel2ndrow"
+// block for row 2, utils/text-font.js's buildTextScrollCursorOverride for
+// the cursor) - hooks/rom.js resolves the real name via
+// Blockly.BBasic.nameDB_ the same way it already does for
+// textLinesMaxVarName/textLinesBaseVarName, for the same reason (see that
+// function's own doc comment).
+export const textRow2ColorVarName = () => '_textRow2Color';
+export const textScrollCursorColorVarName = () => '_textScrollCursorColor';
+// The "end of message" icon's own color (via "Text: set end icon color",
+// text_minikernel_set_end_icon_color below) - the icon draws on GRP1 (its
+// own separate COLUP1), so it can have a different color than the up/down
+// arrows on GRP0/COLUP0 - see buildTextScrollCursorOverride's own comment
+// in utils/text-font.js for why it moved back to GRP1 (needing its own
+// repositioning HMOVE) after briefly sharing GRP0's own low nibble.
+export const textEndIconColorVarName = () => '_textEndIconColor';
+
 // The standard kernel's own code calls "jsr minikernel" as a plain,
 // same-bank call (never a bankswitched "BS_jsr") - so on a bankswitched ROM,
 // text12a.asm/text12b.asm (and the data table between them) have to be
@@ -109,26 +131,33 @@ export const encodeTextMessageLines = (text, justify = 'left', maxWidth = resolv
 // entry it's showing until runtime, so it normally computes the static
 // row's own byte offset with a cheap "id * TEXT_MESSAGE_LENGTH" multiply -
 // correct ONLY when every entry is exactly one row wide. The moment any one
-// entry in the project has "Wrap to line 2" on, that uniform-stride
-// assumption breaks (a wrapping entry earlier in id order pushes every
+// entry in the project has more than one row - "Wrap to line 2" on with
+// overflow text, or (since getStaticMessageLayout always splits regardless
+// of that toggle now) simply a plain message long enough to word-wrap - that
+// uniform-stride assumption breaks (an earlier multi-row entry pushes every
 // later entry's own offset further out than a flat multiply would land on),
 // so that block falls back to a real runtime table lookup instead - same
 // "small parallel tables, one byte per Text tab entry (including the
 // reserved blank guard row)" shape as text-scroll.js's own text_offsets/
 // text_scroll_max tables, and the same per-bank-copy scheme (a table can
 // only be read correctly from the bank it's declared in - see
-// dataTableSymbolName/trackDataTableBank in generators/bbasic.js). Only
-// ever generated at all when isTextRow2Used() is true (see
-// generateTextStaticOffsetTables below), matching TextRow2Active's own dim
-// gate:
+// dataTableSymbolName/trackDataTableBank in generators/bbasic.js). Only ever
+// generated at all when isTextMultiRowUsed() is true (see
+// generateTextStaticOffsetTables below) - a DIFFERENT, broader condition
+// than isTextRow2Used()/TextRow2Active's own dim gate now that a message can
+// have multiple rows without "Wrap to line 2" ever being on:
 //   text_static_offsets - that entry's own row 1 byte offset (also doubles
 //     as its own lowest valid TextIndex, for "Scroll text lines up").
-//   text_has_row2 (0 or 1) - tells the kernel whether to also draw row 2 at
-//     all (see text12b.asm's own "textkernel2ndrow" block) - true for
-//     every entry with 2+ lines, regardless of current scroll position.
+//   text_has_row2 (0 or 1) - tells the kernel whether to also draw row 2
+//     automatically, alongside row 1 with no scrolling needed (see
+//     text12b.asm's own "textkernel2ndrow" block) - true only for an entry
+//     with BOTH 2+ lines AND "Wrap to line 2" actually on; a multi-row entry
+//     with that toggle off still has real row 2+ data (reachable via
+//     "Scroll text lines down"), it just never draws automatically.
 //   text_lines_max - that entry's own HIGHEST valid TextIndex (its own row
 //     1 offset when it has only 1 line, i.e. no scroll room at all) - for
-//     "Scroll text lines down"'s own clamp.
+//     "Scroll text lines down"'s own clamp. Applies regardless of "Wrap to
+//     line 2", same reasoning as text_static_offsets above.
 const TEXT_STATIC_OFFSET_TABLE_ID = '__text_static_offsets';
 const TEXT_HAS_ROW2_TABLE_ID = '__text_has_row2';
 const TEXT_LINES_MAX_TABLE_ID = '__text_lines_max';
@@ -143,18 +172,20 @@ export const trackTextStaticOffsetUsage = (Blockly, bank) => {
 // generators/bbasic.js's own finish() for bank 1's own copy and
 // generateRelocatedSections for each relocated bank's own copy) - same
 // "nothing ever read it, no bank 1 copy either" behavior as
-// generateTextOffsetTables when isTextRow2Used() is false (the common
-// case), so a project that never uses "Wrap to line 2" pays nothing for
-// this at all.
+// generateTextOffsetTables when isTextMultiRowUsed() is false (the common
+// case), so a project with only single-row messages pays nothing for this
+// at all.
 export const generateTextStaticOffsetTables = (Blockly, bank) => {
-  if (!Blockly.BBasic.isTextRow2Used()) return '';
+  if (!Blockly.BBasic.isTextMultiRowUsed()) return '';
   const usage = Blockly.BBasic.dataTableBankUsage[TEXT_STATIC_OFFSET_TABLE_ID];
   if (!(usage ? usage.has(bank) : bank === 1)) return '';
   const layout = getStaticMessageLayout();
   const offsets = layout.map((entry) => `${entry.offset}`).join(', ');
-  const hasRow2Bytes = layout.map((entry) => (entry.lineCount >= 2 ? 1 : 0)).join(', ');
+  const hasRow2Bytes = layout.map((entry) => (entry.wrapToLine2 && entry.lineCount >= 2 ? 1 : 0)).join(', ');
+  // Same "-2 with auto row 2, -1 without" distinction as
+  // text_minikernel_show_named's own maxOffset - see its comment.
   const linesMax = layout.map((entry) =>
-    `${entry.offset + Math.max(0, entry.lineCount - 2) * TEXT_MESSAGE_LENGTH}`).join(', ');
+    `${entry.offset + Math.max(0, entry.lineCount - (entry.wrapToLine2 ? 2 : 1)) * TEXT_MESSAGE_LENGTH}`).join(', ');
   return ` data text_static_offsets\n  ${offsets}\nend\n\n data text_has_row2\n  ${hasRow2Bytes}\nend\n\n` +
     ` data text_lines_max\n  ${linesMax}\nend`;
 };
@@ -186,6 +217,13 @@ export default (Blockly) => {
   // be a flat position*TEXT_MESSAGE_LENGTH computation.
   const namedMessageOffset = (id) => getStaticMessageLayout()[namedMessagePosition(id)].offset;
   const namedMessageLineCount = (id) => getStaticMessageLayout()[namedMessagePosition(id)].lineCount;
+  // Whether row 2+ should draw AUTOMATICALLY (alongside row 1, no scrolling
+  // needed) for this entry - "Wrap to line 2" itself, not lineCount (which
+  // is now independent of that toggle - see getStaticMessageLayout's own
+  // comment). A message can have real, scrollable 2nd+ row data with this
+  // false: "Scroll text lines down" still reveals it, one row at a time,
+  // just never automatically.
+  const namedMessageWrapToLine2 = (id) => getStaticMessageLayout()[namedMessagePosition(id)].wrapToLine2;
 
   // Free-typed messages ("Show text: <literal>") have no Text tab entry to
   // number them by, so they keep the old lazy, dedup-by-content scheme,
@@ -271,17 +309,30 @@ export default (Blockly) => {
   ];
 
   // Plain named block: always the ordinary static row(s) (namedMessageOffset -
-  // one row, or as many as splitMessageLines needed if this entry has "Wrap
-  // to line 2" on), maxOffset always 0 - never touches the scroll append
-  // region at all.
+  // one row, or as many as splitMessageLines needed - always, regardless of
+  // "Wrap to line 2" now, see getStaticMessageLayout's own comment), maxOffset
+  // always 0 - never touches the scroll append region at all. Row 2 only
+  // draws automatically when "Wrap to line 2" is ALSO on (namedMessageWrapToLine2)
+  // - a multi-row entry with it off still has real, scrollable row 2+ data
+  // (setTextLinesRangeCode below), just never shown without scrolling to it.
   Blockly.BBasic['text_minikernel_show_named'] = function(block) {
     markTextMinikernelUsed();
     const id = block.getFieldValue('TEXT_ID');
     const offset = namedMessageOffset(id);
     const lineCount = namedMessageLineCount(id);
-    const maxOffset = offset + Math.max(0, lineCount - 2) * TEXT_MESSAGE_LENGTH;
+    const wrapToLine2 = namedMessageWrapToLine2(id);
+    // With "Wrap to line 2" on, the LAST two lines are already both visible
+    // at once (row 1 + auto-drawn row 2), so there's no need to scroll all
+    // the way to the very last one - lineCount-2. Without it, only one row
+    // is EVER on screen at a time (row 2 never auto-draws - see
+    // setTextRow2ActiveCode below), so reaching the last line means
+    // scrolling through every single one - lineCount-1. Using the "-2"
+    // formula regardless of wrapToLine2 was a real bug: it left the very
+    // last line of a non-wrapping multi-line message permanently
+    // unreachable, since max never advanced far enough to uncover it.
+    const maxOffset = offset + Math.max(0, lineCount - (wrapToLine2 ? 2 : 1)) * TEXT_MESSAGE_LENGTH;
     return emitScrollSetup(offset, 0, DEFAULT_SCROLL_SPEED, DEFAULT_SCROLL_PAUSE) +
-      setTextRow2ActiveCode(lineCount >= 2) +
+      setTextRow2ActiveCode(wrapToLine2 && lineCount >= 2) +
       setTextLinesRangeCode(offset, maxOffset);
   };
   // Scroll named block: uses the SAME position to look up that entry's own
@@ -354,23 +405,31 @@ export default (Blockly) => {
     // static region really is a uniform TEXT_MESSAGE_LENGTH stride - the
     // plain multiply (needing div_mul.asm - see Blockly.BBasic.usesDivMul's
     // own comment elsewhere in this codebase) is cheaper than a table read
-    // and stays exactly correct.
-    if (!Blockly.BBasic.isTextRow2Used()) {
+    // and stays exactly correct. isTextMultiRowUsed(), not isTextRow2Used() -
+    // a plain message can need a second row purely from word-wrap now, with
+    // "Wrap to line 2" never coming into it at all (see
+    // getStaticMessageLayout's own comment), so THAT'S the real condition
+    // this uniform-stride shortcut depends on.
+    if (!Blockly.BBasic.isTextMultiRowUsed()) {
       Blockly.BBasic.usesDivMul = true;
       const offsetExpr = `${argPair.read} * ${TEXT_MESSAGE_LENGTH}`;
       return captureArg +
         emitScrollSetup(offsetExpr, 0, DEFAULT_SCROLL_SPEED, DEFAULT_SCROLL_PAUSE) +
         setTextLinesRangeCode(offsetExpr, offsetExpr);
     }
-    // Slow path: some entry DOES wrap, so row widths aren't uniform any
-    // more - the offset, whether row 2 applies, and the valid scroll range
-    // all have to come from a real runtime table lookup instead (see
-    // text_static_offsets/text_has_row2/text_lines_max's own comment
-    // above).
+    // Slow path: some entry has 2+ rows, so row widths aren't uniform any
+    // more - the offset and the valid scroll range both have to come from a
+    // real runtime table lookup instead (see text_static_offsets/
+    // text_has_row2/text_lines_max's own comment above). The
+    // "TextRow2Active = text_has_row2[...]" write itself is only emitted
+    // when isTextRow2Used() is ALSO true (some entry actually has "Wrap to
+    // line 2" on) - TextRow2Active isn't even dimmed otherwise (see
+    // generateTextMinikernelDims), since nothing would ever need row 2 to
+    // auto-draw in that case.
     trackTextStaticOffsetUsage(Blockly, Blockly.BBasic.getCurrentBank());
     return captureArg +
       emitScrollSetup(`text_static_offsets[${argPair.read}]`, 0, DEFAULT_SCROLL_SPEED, DEFAULT_SCROLL_PAUSE) +
-      `TextRow2Active = text_has_row2[${argPair.read}]\n` +
+      (Blockly.BBasic.isTextRow2Used() ? `TextRow2Active = text_has_row2[${argPair.read}]\n` : '') +
       setTextLinesRangeCode(`text_static_offsets[${argPair.read}]`, `text_lines_max[${argPair.read}]`);
   };
   // Scroll by-id block: normally WHICH entry gets shown isn't known until
@@ -498,11 +557,53 @@ export default (Blockly) => {
       setTextLinesRangeCode(0, 0);
   };
 
+  // ROW picks which row(s) this sets: "1" (the default - a project saved
+  // before this dropdown existed has no ROW field serialized at all, so
+  // Blockly falls back to the block's own default value here, keeping its
+  // exact old, row-1-only behavior), "2" (row 2's own dev var - see
+  // textRow2ColorVarName's own comment above for why that needs a real dev
+  // var, unlike TextColor), or "both". "Both" deliberately only writes
+  // TextColor, the same as "1" - row 2 already follows TextColor
+  // automatically whenever its own var hasn't been explicitly written (see
+  // buildTextRow2ColorOverride's own "$01 sentinel" comment in
+  // utils/text-font.js), so writing a redundant second copy into row 2's
+  // var here would only cost cycles/bytes for no visible difference, and
+  // would stop row 2 from tracking any LATER TextColor change (a fade, or
+  // another "both"/"row 1" set) the way the automatic fallback otherwise
+  // does. Only "2" ever writes row 2's own var, switching it from
+  // "following row 1" to "independent" from that point on.
   Blockly.BBasic['text_minikernel_set_color'] = function(block) {
     markTextMinikernelUsed();
     const argument0 = Blockly.BBasic.valueToCode(block, 'VALUE',
         Blockly.BBasic.ORDER_ASSIGNMENT) || '0';
+    const row = block.getFieldValue('ROW') || '1';
+    if (row === '2') {
+      const varName = Blockly.BBasic.nameDB_.getName(
+          textRow2ColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+      return `${varName} = ${argument0}\n`;
+    }
     return `TextColor = ${argument0}\n`;
+  };
+
+  // The scroll cursor's own color (see textScrollCursorColorVarName's own
+  // comment above).
+  Blockly.BBasic['text_minikernel_set_cursor_color'] = function(block) {
+    markTextMinikernelUsed();
+    const argument0 = Blockly.BBasic.valueToCode(block, 'VALUE',
+        Blockly.BBasic.ORDER_ASSIGNMENT) || '0';
+    const varName = Blockly.BBasic.nameDB_.getName(
+        textScrollCursorColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+    return `${varName} = ${argument0}\n`;
+  };
+
+  // The end icon's own color (see textEndIconColorVarName's own comment).
+  Blockly.BBasic['text_minikernel_set_end_icon_color'] = function(block) {
+    markTextMinikernelUsed();
+    const argument0 = Blockly.BBasic.valueToCode(block, 'VALUE',
+        Blockly.BBasic.ORDER_ASSIGNMENT) || '0';
+    const varName = Blockly.BBasic.nameDB_.getName(
+        textEndIconColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+    return `${varName} = ${argument0}\n`;
   };
 
   Blockly.BBasic['text_minikernel_fade_to'] = function(block) {
@@ -546,6 +647,21 @@ export default (Blockly) => {
     return [code, Blockly.BBasic.ORDER_EQUALITY];
   };
 
+  // True exactly when the scroll cursor's own "end of message" icon would
+  // currently be showing (see buildTextScrollCursorOverride's own matching
+  // check in utils/text-font.js) - _textLinesMax is already the highest
+  // value TextIndex can hold for the currently shown message, so "nothing
+  // left below" is just TextIndex reaching it. Deliberately the real dev
+  // vars, not the cursor's own scorepointers scratch bytes (those are only
+  // ever valid transiently during the minikernel's own scanlines, not
+  // readable from ordinary game logic running elsewhere in the frame).
+  Blockly.BBasic['text_minikernel_end_icon_visible'] = function(block) {
+    markTextMinikernelUsed();
+    const linesMax = Blockly.BBasic.nameDB_.getName(
+        textLinesMaxVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+    return [`TextIndex >= ${linesMax}`, Blockly.BBasic.ORDER_RELATIONAL];
+  };
+
   // See text_minikernel_scroll_control's own comment in blocks/
   // text-minikernel.js for what each action means. All five just write the
   // shared scroll state directly (see text-scroll.js) - none of them need
@@ -586,9 +702,10 @@ export default (Blockly) => {
     return resetToStart + `${state} = 0\n` + `${timer} = ${pauseDuration}\n`;
   };
 
-  // Moves the CURRENTLY shown message up/down by one line (TextIndex +/-
-  // TEXT_MESSAGE_LENGTH) when it has more than 2 lines (see splitMessageLines
-  // in text-minikernel-layout.js) - only the first 2 of any message's own
+  // Moves the CURRENTLY shown message up/down by one or two lines (the
+  // block's own LINES dropdown - TextIndex +/- TEXT_MESSAGE_LENGTH, once per
+  // line) when it has more than 2 lines (see splitMessageLines in
+  // text-minikernel-layout.js) - only the first 2 of any message's own
   // lines are ever drawn at once (text12b.asm's own "textkernel2ndrow"
   // block always reads row 2 from TextIndex+TEXT_MESSAGE_LENGTH), so this is
   // how the rest come into view. Clamped directly against TextIndex itself,
@@ -598,19 +715,39 @@ export default (Blockly) => {
   // base = max, so both blocks are harmless no-ops for it. No multiply
   // needed either way: every line is exactly TEXT_MESSAGE_LENGTH bytes
   // apart, so moving one line at a time is just a plain add/subtract.
+  //
+  // A 2-line move is two separate single-line guarded steps in a row, NOT
+  // one step of 2*TEXT_MESSAGE_LENGTH - TextIndex only ever sits at exactly
+  // base + TEXT_MESSAGE_LENGTH*k (k>=0), so this single-line guard
+  // ("if TextIndex > base then ...") is already known safe on its own (the
+  // same code this always was, before LINES existed) - repeating it can
+  // never step past base even when only one line of room remains, because
+  // the SECOND guard re-checks TextIndex fresh after the first one already
+  // moved it. A single combined "- 2*TEXT_MESSAGE_LENGTH" step, guarded by
+  // one check against base, would NOT have this safety: with only one
+  // line's worth of room left, that single big step would undershoot past
+  // base (or, for "down", overshoot past max) before the guard ever gets a
+  // chance to re-examine TextIndex partway through.
+  const buildLineScrollSteps = (block, bound, direction) => {
+    const lines = Number(block.getFieldValue('LINES')) || 1;
+    const step = direction === 'up' ?
+      `if TextIndex > ${bound} then TextIndex = TextIndex - ${TEXT_MESSAGE_LENGTH}\n` :
+      `if TextIndex < ${bound} then TextIndex = TextIndex + ${TEXT_MESSAGE_LENGTH}\n`;
+    return step.repeat(Math.max(1, Math.min(2, lines)));
+  };
   Blockly.BBasic['text_minikernel_line_scroll_up'] = function(block) {
     markTextMinikernelUsed();
     const resolveVar = (canonicalName) =>
       Blockly.BBasic.nameDB_.getName(canonicalName, Blockly.Names.DEVELOPER_VARIABLE_TYPE);
     const base = resolveVar(textLinesBaseVarName());
-    return `if TextIndex > ${base} then TextIndex = TextIndex - ${TEXT_MESSAGE_LENGTH}\n`;
+    return buildLineScrollSteps(block, base, 'up');
   };
   Blockly.BBasic['text_minikernel_line_scroll_down'] = function(block) {
     markTextMinikernelUsed();
     const resolveVar = (canonicalName) =>
       Blockly.BBasic.nameDB_.getName(canonicalName, Blockly.Names.DEVELOPER_VARIABLE_TYPE);
     const max = resolveVar(textLinesMaxVarName());
-    return `if TextIndex < ${max} then TextIndex = TextIndex + ${TEXT_MESSAGE_LENGTH}\n`;
+    return buildLineScrollSteps(block, max, 'down');
   };
 
   // Drives generateSystemDims()'s TextIndex/TextDataPtr dims below - needs to
@@ -640,6 +777,37 @@ export default (Blockly) => {
   // what the PLAIN Show text blocks can ever act on.
   Blockly.BBasic.isTextRow2Used = function() {
     return this.isTextMinikernelActive() && listTextStrings().some((entry) => entry.wrapToLine2);
+  };
+
+  // Whether TextRow2Active itself needs to be dimmed - a BROADER condition
+  // than isTextRow2Used() just above, which still gates ONLY the real,
+  // expensive row-2-drawing kernel feature (textkernel2ndrow). The "more
+  // below" scroll cursor (see generators/bbasic.js's own
+  // textScrollCursorConfigurationCode) reads TextRow2Active directly in
+  // hand-written asm too, for ANY project using it, even one where no
+  // message ever actually has "Wrap to line 2" on - it still needs the
+  // BYTE to exist (reading as 0/false, correctly meaning "single row mode"
+  // for every message in that case), just never the costly kernel feature
+  // itself. Keeping these two checks separate is what stops turning on the
+  // cursor from silently turning on ~13 extra scanlines of row-2-drawing
+  // code nothing in the project actually asked for.
+  Blockly.BBasic.needsTextRow2ActiveDim = function() {
+    return this.isTextRow2Used() || !!this.textScrollCursorUsed;
+  };
+
+  // Whether ANY Text tab entry occupies more than one row - a BROADER check
+  // than isTextRow2Used() just above, now that getStaticMessageLayout splits
+  // a message into real, separate rows regardless of "Wrap to line 2" (a
+  // plain overlong message word-wraps into row 2+ too, it just never draws
+  // automatically without that toggle - see namedMessageWrapToLine2's own
+  // comment). Drives whether the static region's own byte offsets are still
+  // a uniform TEXT_MESSAGE_LENGTH stride (text_minikernel_show_by_id's own
+  // fast/slow path) and whether text_static_offsets/text_has_row2/
+  // text_lines_max get reserved/generated at all (generateTextStaticOffsetTables) -
+  // a project where every message fits on one line pays nothing for any of
+  // this, same as before "Wrap to line 2" existed at all.
+  Blockly.BBasic.isTextMultiRowUsed = function() {
+    return this.isTextMinikernelActive() && getStaticMessageLayout().some((entry) => entry.lineCount >= 2);
   };
 
   // Whether the project uses "Scroll text lines up/down" anywhere - a real
@@ -674,11 +842,13 @@ export default (Blockly) => {
   // same reason TextIndex/TextDataPtr aren't just ordinary auto-lettered
   // dev vars) - var45, the one byte of the documented "var44-47 always
   // free" pool (see reserveDevVarRW's own comment in generators/bbasic.js)
-  // neither TextIndex (44) nor TextDataPtr (46-47) ever claims. Only
-  // dimmed when isTextRow2Used() is true - the exact same condition that
-  // gates text12b.asm's own "textkernel2ndrow" ifconst block in the first
-  // place (see generateConfiguration in generators/bbasic.js), so a
-  // project that never turns on "Wrap to line 2" never reserves it.
+  // neither TextIndex (44) nor TextDataPtr (46-47) ever claims. Dimmed
+  // whenever needsTextRow2ActiveDim() is true - either "Wrap to line 2" is
+  // actually used somewhere (the same condition that separately gates
+  // text12b.asm's own, far more expensive "textkernel2ndrow" ifconst block -
+  // see generateConfiguration in generators/bbasic.js), or the "more below"
+  // scroll cursor is on and needs to read this byte regardless (see
+  // needsTextRow2ActiveDim's own comment above).
   Blockly.BBasic.generateTextMinikernelDims = function() {
     if (!this.isTextMinikernelActive()) return '';
     const configurationStorage = useConfigurationStorage();
@@ -692,7 +862,7 @@ export default (Blockly) => {
     const textIndexDim = `\n dim TextIndex = var44${textIndexComment}`;
     const textDataPtrDim = this.pfscoreEnabledForTextMinikernel ?
       `\n dim TextDataPtr = var46${textDataPtrComment}` : '';
-    const textRow2ActiveDim = this.isTextRow2Used() ?
+    const textRow2ActiveDim = this.needsTextRow2ActiveDim() ?
       `\n dim TextRow2Active = var45${textRow2ActiveComment}` : '';
     return textIndexDim + textDataPtrDim + textRow2ActiveDim;
   };
@@ -706,7 +876,29 @@ export default (Blockly) => {
   // the reference demo (which explicitly sets white) nor a readable default.
   Blockly.BBasic.generateTextMinikernelDefaults = function() {
     if (!this.isTextMinikernelActive()) return '';
-    return ' TextColor = $0F';
+    const lines = [' TextColor = $0F'];
+    // Row 2's own color defaults to the "$01 sentinel" (see
+    // buildTextRow2ColorOverride's own comment in utils/text-font.js), not a
+    // real color - it means "follow TextColor" until a "Text: set color"
+    // block explicitly targets row 2 and overwrites it with a real (always
+    // even) color byte. Matches the reservation's own gate exactly
+    // (isTextRow2Used() or some "Text: set color" block actually targeting
+    // row 2) - row 1 is that dropdown's own default, so most projects never
+    // reserve or default this var at all.
+    if (this.isTextRow2Used() || this.textRow2ColorBlockUsed) {
+      const row2Color = Blockly.BBasic.nameDB_.getName(
+          textRow2ColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+      lines.push(` ${row2Color} = $01`);
+    }
+    if (this.textScrollCursorUsed) {
+      const cursorColor = Blockly.BBasic.nameDB_.getName(
+          textScrollCursorColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+      lines.push(` ${cursorColor} = $0E`);
+      const endIconColor = Blockly.BBasic.nameDB_.getName(
+          textEndIconColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+      lines.push(` ${endIconColor} = $0E`);
+    }
+    return lines.join('\n');
   };
 
   // Spliced into bbasic.bb.hbs right after the data tables section (see
@@ -770,11 +962,14 @@ export default (Blockly) => {
     const glyphRows = (glyphs) => chunk(glyphs, 16).map((row) => '  ' + row.join(', '));
 
     const maxWidth = resolveTextMaxDisplayWidth();
-    const staticEntries = [{text: '', justify: 'left', wrapToLine2: false}, ...listTextStrings()];
-    const namedRows = staticEntries.flatMap(({text, justify, wrapToLine2}) => {
-      if (!wrapToLine2) return glyphRows(encodeTextMessage(text, justify, maxWidth));
-      return encodeTextMessageLines(text, justify, maxWidth).flatMap((glyphs) => glyphRows(glyphs));
-    });
+    const staticEntries = [{text: '', justify: 'left'}, ...listTextStrings()];
+    // Always splits into as many rows as splitMessageLines needs, regardless
+    // of "Wrap to line 2" - that toggle no longer decides whether row 2+
+    // data EXISTS (see getStaticMessageLayout's own comment), only whether
+    // it draws automatically (namedMessageWrapToLine2/setTextRow2ActiveCode
+    // above).
+    const namedRows = staticEntries.flatMap(({text, justify}) =>
+      encodeTextMessageLines(text, justify, maxWidth).flatMap((glyphs) => glyphRows(glyphs)));
     const freeTypedRows = (this.freeTypedMessages || []).flatMap((text) =>
       glyphRows(encodeTextMessage(text, 'left', maxWidth)));
     const namedScrollRows = getNamedScrollLayout()

--- a/src/hooks/project.js
+++ b/src/hooks/project.js
@@ -49,6 +49,8 @@ export const useDataTablesStorage = () =>
   withRomInvalidation(useJsonProjectStorage('dataTables'));
 export const useTextStringsStorage = () =>
   withRomInvalidation(useJsonProjectStorage('textStrings'));
+export const useTextFontStorage = () =>
+  withRomInvalidation(useJsonProjectStorage('textFont'));
 export const useSongsStorage = () =>
   withRomInvalidation(useJsonProjectStorage('songs'));
 

--- a/src/hooks/rom.js
+++ b/src/hooks/rom.js
@@ -13,11 +13,15 @@ import {getExtendedScoreGraphics, getTextMinikernelSiblingFiles} from '../genera
 import {processBackgroundStorageDefaults} from '../blocks/background';
 import {findSongById} from '../blocks/music';
 import {buildScoreFontOverride, SQUISH_SCORE_FONT} from '../utils/score-font';
+import {buildTextFontOverride, buildTextScrollCursorOverride, buildTextRow2ColorOverride,
+  packCursorGlyphByte, processCursorGlyphDefaults, resolveBlinkMask} from '../utils/text-font';
+import {textLinesMaxVarName, textLinesBaseVarName, textRow2ColorVarName,
+  textScrollCursorColorVarName, textEndIconColorVarName} from '../generators/bbasic/text-minikernel';
 import {showError} from '../utils/build-error';
 import {computeRomCapacity} from '../utils/rom-capacity';
 import {useGeneratedBasic} from './generated';
 import {appendCompileLog, clearCompileLog, useBackgroundsStorage, useConfigurationStorage, useErrorStorage,
-  usePlayer0Storage, usePlayer1Storage, useWorkspaceStorage} from './project';
+  usePlayer0Storage, usePlayer1Storage, useTextFontStorage, useWorkspaceStorage} from './project';
 import {getRelocationBanks, resetRelocationBanks, setRelocationBank,
   recordSuccessfulRelocationBanks, seedRelocationBanksFromLastSuccess} from './relocation-banks';
 import {markRomUpToDate, markRomOutdated, useRomOutdated, useHasCompiledRom} from './rom-status';
@@ -970,6 +974,50 @@ export const buildRom = async () => {
       } else {
         const scoreFontOverride = await buildScoreFontOverride(config.scoreFont);
         if (scoreFontOverride) siblingFiles['score_graphics.asm'] = scoreFontOverride;
+      }
+      // Same override mechanism, for the Text Minikernel's own drawn
+      // character set (see utils/text-font.js) - only reachable when the
+      // Text Minikernel is active at all (siblingFiles only carries
+      // text12b.asm in the first place then), and only actually returns an
+      // override once the Text Font Editor has ever written to storage.
+      if (textMinikernelActive) {
+        const textFontOverride = await buildTextFontOverride();
+        if (textFontOverride) siblingFiles['text12b.asm'] = textFontOverride;
+        // Row 2's own color ("Text: set row 2 color" block) - see
+        // buildTextRow2ColorOverride's own doc comment in utils/text-font.js.
+        // Real resolved name read off BlocklyBB.nameDB_ the same way
+        // linesMaxVarName/linesBaseVarName are below.
+        if (BlocklyBB.isTextRow2Used()) {
+          const colorVarName = BlocklyBB.nameDB_.getName(
+              textRow2ColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+          siblingFiles['text12b.asm'] = buildTextRow2ColorOverride(
+              siblingFiles['text12b.asm'], {colorVarName});
+        }
+        // The "more below" scroll cursor (see utils/text-font.js's own
+        // buildTextScrollCursorOverride) splices its own drawing code into
+        // WHATEVER text12b.asm content is already staged above (the font
+        // override, if any, otherwise the sibling file's own pristine
+        // copy) - applied on top, not instead of, so a project customizing
+        // both its glyphs AND the cursor gets both at once. _textLinesMax's
+        // own real resolved name is read directly off BlocklyBB.nameDB_
+        // here, right after this same build's regenerateCode() call
+        // already resolved it the same way for the actual generated source
+        // (see that function's own doc comment in utils/text-font.js for
+        // why a standalone util module can't resolve this on its own).
+        if (config.enableTextScrollCursor) {
+          const glyphByte = packCursorGlyphByte(processCursorGlyphDefaults(useTextFontStorage()));
+          const linesMaxVarName = BlocklyBB.nameDB_.getName(
+              textLinesMaxVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+          const linesBaseVarName = BlocklyBB.nameDB_.getName(
+              textLinesBaseVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+          const colorVarName = BlocklyBB.nameDB_.getName(
+              textScrollCursorColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+          const endColorVarName = BlocklyBB.nameDB_.getName(
+              textEndIconColorVarName(), Blockly.Names.DEVELOPER_VARIABLE_TYPE);
+          const blinkMask = resolveBlinkMask(config.textScrollCursorBlinkSpeed);
+          siblingFiles['text12b.asm'] = buildTextScrollCursorOverride(siblingFiles['text12b.asm'],
+              {glyphByte, linesMaxVarName, linesBaseVarName, colorVarName, endColorVarName, blinkMask});
+        }
       }
       // Passed to every stage below so each one's own real CLI invocation
       // (and, once it finishes, how long it took) appears live in the error

--- a/src/utils/file-handle-storage.js
+++ b/src/utils/file-handle-storage.js
@@ -76,3 +76,31 @@ export const ensureWritePermission = async (handle) => {
   if ((await handle.requestPermission(options)) === 'granted') return true;
   return false;
 };
+
+// The Electron build's own equivalent of the above, for the active
+// project's absolute file path (see background.js's own project:save-as/
+// project:open handlers) rather than a FileSystemFileHandle - a plain
+// string, so localStorage (not IndexedDB) is enough to persist it across
+// a reload.
+const ACTIVE_PATH_KEY = 'vcs-game-maker-active-project-path';
+
+export const persistActiveFilePath = (filePath) => {
+  try {
+    if (filePath) {
+      localStorage.setItem(ACTIVE_PATH_KEY, filePath);
+    } else {
+      localStorage.removeItem(ACTIVE_PATH_KEY);
+    }
+  } catch (e) {
+    console.error('Error while persisting the active project file path', e);
+  }
+};
+
+export const loadPersistedFilePath = () => {
+  try {
+    return localStorage.getItem(ACTIVE_PATH_KEY);
+  } catch (e) {
+    console.error('Error while loading the persisted active project file path', e);
+    return null;
+  }
+};

--- a/src/utils/text-font.js
+++ b/src/utils/text-font.js
@@ -1,0 +1,620 @@
+import {CHAR_TO_GLYPH} from '../blocks/text-strings';
+import {getPristineText12b} from '../generators/bbasic/text-minikernel-files';
+import {useTextFontStorage} from '../hooks/project';
+
+// Every glyph the Text Minikernel can draw is a fixed 4-pixel-wide, 5-row
+// -tall shape (confirmed directly against public/bb19/text-minikernel/
+// text12b.asm's own left_text/right_text tables: each row is stored as one
+// byte with only its high nibble - left_text - or low nibble - right_text -
+// ever set, the other 4 bits always 0). The kernel draws two adjacent
+// half-width characters per GRP0/GRP1 write by ORing a "left" glyph's
+// left_text byte with a "right" glyph's right_text byte together - see
+// buildTextFontOverride's own comment below for exactly how that's
+// reconstructed from a single 4x5 pixel matrix per glyph.
+export const TEXT_GLYPH_WIDTH = 4;
+export const TEXT_GLYPH_HEIGHT = 5;
+
+// The exact order glyph labels appear in text12b.asm's own left_text table -
+// confirmed directly against the vendored file. This is the REAL on-disk
+// byte layout (glyph N's 5 bytes start at offset N*TEXT_GLYPH_HEIGHT within
+// text_data), not just a display convenience, so buildTextFontOverride can
+// safely walk both the pristine file's own .byte lines and this app's own
+// stored glyph array in lockstep.
+const GLYPH_LABEL_ORDER = [
+  '__A', '__B', '__C', '__D', '__E', '__F', '__G', '__H', '__I', '__J', '__K', '__L', '__M',
+  '__N', '__O', '__P', '__Q', '__R', '__S', '__T', '__U', '__V', '__W', '__X', '__Y', '__Z',
+  '__0', '__1', '__2', '__3', '__4', '__5', '__6', '__7', '__8', '__9',
+  '_sp', '_pd', '_qu', '_ex', '_cm', '_hy', '_pl', '_ap', '_lp', '_rp', '_co', '_sl', '_eq', '_qt', '_po',
+];
+
+// Maps each glyph label back to the character it represents, purely for the
+// editor's own display labels - reusing CHAR_TO_GLYPH (blocks/text-strings.js,
+// the same map encodeTextMessage itself reads) as the single source of truth
+// for that association, rather than a second, independently-typed char list
+// that could quietly drift out of sync with it.
+const GLYPH_TO_CHAR = Object.fromEntries(
+    Object.entries(CHAR_TO_GLYPH).map(([ch, label]) => [label, ch]));
+
+export const TEXT_GLYPH_ORDER = GLYPH_LABEL_ORDER.map((label) => ({label, char: GLYPH_TO_CHAR[label] || label}));
+// 51 - exactly fills the 255 bytes (51 * 5) a single 8-bit glyph index can
+// address at all (see TextPointersLoop/showtextrow in text12b.asm - the
+// index is the glyph's own raw byte offset into text_data, capped at 255).
+// This is a firm hardware ceiling, not a chosen limit: there is no spare
+// room for a 52nd glyph without changing the addressing scheme entirely, so
+// this editor only ever lets these 51 be REDRAWN, never adds a new one.
+export const TEXT_GLYPH_COUNT = TEXT_GLYPH_ORDER.length;
+
+// Anchors used to locate the pristine file's own left_text/right_text
+// sections (see buildTextFontOverride below) - 'text_data\n\nleft_text' is
+// unique to the real table label (plain "left_text,x" - with a comma -
+// appears many times earlier, in the kernel's own drawing code, so a bare
+// "left_text" search would land on the wrong, much earlier occurrence).
+// 'text_data_height' only appears once as an actual label (a second,
+// harmless use as an operand - "if >. != >[.+text_data_height]" - comes
+// right after it, past wherever this search starts from). 'right_text' is
+// searched for starting from THAT point on, which is safely past every
+// earlier "ora right_text,x" instruction reference, so no special anchor is
+// needed for it the way left_text needs one.
+// A plain literal string search doesn't work for this: the vendored file
+// uses CRLF line endings, not the bare "\n" a literal-string anchor would
+// need to match. A regex tolerates either.
+const LEFT_TABLE_ANCHOR_RE = /text_data\r?\n\r?\nleft_text/;
+const HEIGHT_LABEL = 'text_data_height';
+const RIGHT_TABLE_LABEL = 'right_text';
+
+// Returns the index right at "left_text" itself (just past the anchor's own
+// "text_data\n\n" prefix), or -1 if the pristine file isn't shaped as
+// expected.
+const findLeftTextStart = (text12b) => {
+  const match = LEFT_TABLE_ANCHOR_RE.exec(text12b);
+  return match ? match.index + match[0].length - 'left_text'.length : -1;
+};
+
+const BYTE_LINE_RE = /\.byte\s+%[01]{8}/g;
+
+// Parses one section's own sequence of ".byte %XXXXXXXX" lines, in order,
+// into an array of 8-char bit strings - used both to read the pristine
+// file's own default glyphs (getDefaultTextFont) and (indirectly, via
+// replaceByteValues below) to rewrite them.
+const parseByteValues = (section) => [...section.matchAll(BYTE_LINE_RE)].map((m) => m[0].match(/[01]{8}/)[0]);
+
+// Replaces every ".byte %XXXXXXXX" line in a section with the given values,
+// in order - preserving every other character (labels, comments, blank
+// lines, indentation) exactly as the pristine file has them, so offsets and
+// addresses stay byte-for-byte identical to the original; only the pixel
+// VALUES change. This is what lets this override skip the ORG/RORG address
+// juggling buildScoreFontOverride (utils/score-font.js) needs - a glyph's
+// on-disk size never changes (see TEXT_GLYPH_COUNT's own "firm hardware
+// ceiling" comment), so there is never a byte count to compensate for.
+const replaceByteValues = (section, values) => {
+  let i = 0;
+  return section.replace(BYTE_LINE_RE, () => `.byte %${values[i++]}`);
+};
+
+// Splits a section's own flat byte-value array (TEXT_GLYPH_COUNT *
+// TEXT_GLYPH_HEIGHT long) into one TEXT_GLYPH_HEIGHT x TEXT_GLYPH_WIDTH
+// pixel matrix per glyph - only the byte's own nibble that this glyph
+// table actually stores data in matters (left_text's high nibble, or
+// right_text's identical low nibble - see this file's own top comment); the
+// other nibble is always zero in the pristine file, and this app never
+// needs to represent it separately at all, since buildTextFontOverride
+// below always re-derives BOTH nibbles fresh from one shared pixel matrix.
+const bytesToGlyphs = (byteValues, nibble) => {
+  const glyphs = [];
+  for (let i = 0; i < TEXT_GLYPH_COUNT; i++) {
+    const rows = byteValues.slice(i * TEXT_GLYPH_HEIGHT, (i + 1) * TEXT_GLYPH_HEIGHT)
+        .map((byte) => (nibble === 'high' ? byte.slice(0, 4) : byte.slice(4)).split('').map(Number));
+    glyphs.push(rows);
+  }
+  return glyphs;
+};
+
+/**
+ * The Text Minikernel's own built-in glyph shapes, one 5-row x 4-col pixel
+ * matrix per glyph (TEXT_GLYPH_ORDER's own order) - parsed once from the
+ * real pristine text12b.asm rather than hand-transcribed, so this can never
+ * drift out of sync with whatever the vendored file actually ships.
+ * @return {!Promise<!Array<!Array<!Array<number>>>>}
+ */
+let defaultTextFontPromise = null;
+export const getDefaultTextFont = () => {
+  if (!defaultTextFontPromise) {
+    defaultTextFontPromise = getPristineText12b().then((text12b) => {
+      const leftStart = findLeftTextStart(text12b);
+      const heightAt = leftStart >= 0 ? text12b.indexOf(HEIGHT_LABEL, leftStart) : -1;
+      if (leftStart < 0 || heightAt < 0) {
+        throw new Error('Unexpected text12b.asm shape - could not locate the left_text glyph table.');
+      }
+      return bytesToGlyphs(parseByteValues(text12b.slice(leftStart, heightAt)), 'high');
+    });
+  }
+  return defaultTextFontPromise;
+};
+
+/**
+ * Fills in a usable glyph set - the stored one if it's shaped as expected,
+ * otherwise the given defaults (same "validate shape, else fall back"
+ * pattern as processScoreFontDefaults in utils/score-font.js).
+ * @param {*} storage Text font storage, or its value.
+ * @param {!Array<!Array<!Array<number>>>} defaultGlyphs From getDefaultTextFont.
+ * @return {{glyphs: !Array<!Array<!Array<number>>>}}
+ */
+export const processTextFontDefaults = (storage, defaultGlyphs) => {
+  const stored = storage && ('value' in storage ? storage.value : storage);
+  const glyphs = stored && stored.glyphs;
+  if (!Array.isArray(glyphs) || glyphs.length !== TEXT_GLYPH_COUNT) {
+    return {glyphs: defaultGlyphs};
+  }
+  return {glyphs};
+};
+
+// The "more below" scroll cursor - text12b.asm's own "textScrollCursor"
+// ifconst block (see generators/bbasic.js's own textScrollCursorConfigurationCode)
+// draws this next to whichever row is currently the last one on screen, only
+// when there's more of the message left to scroll to. Unlike the 51 real
+// glyphs above, this ISN'T part of the indexed text_data table at all - it's
+// never looked up by a runtime glyph index, just a single fixed shape drawn
+// directly by name - so it isn't limited to the 4-bit-wide, half-nibble
+// shape those need to leave room for OR-ing two characters together (see
+// this file's own top comment). With the WHOLE byte to itself, 2 rows of a
+// full 4 bits each fits with zero bits left over: 2 * 4 = 8.
+export const TEXT_CURSOR_WIDTH = 4;
+export const TEXT_CURSOR_HEIGHT = 2;
+
+// A plain downward chevron ("more below") - just a reasonable starting
+// shape, fully editable in the Text Minikernel Font card like any glyph.
+export const DEFAULT_TEXT_CURSOR = [
+  [1, 0, 0, 1],
+  [0, 1, 1, 0],
+];
+
+// The "end of message" icon - a plain filled 2x2 square, drawn on GRP1 (its
+// own COLUP1, independent of the up/down arrows' COLUP0 on GRP0) with a
+// corrective HMOVE (see buildTextScrollCursorOverride) pulling it back in
+// line with the down arrow's own position. Fixed, not user-editable like
+// the up/down glyph - a much smaller, simpler shape that doesn't need its
+// own Font Editor tile.
+export const END_ICON_BYTE = '%11000000';
+
+// The scroll cursor's own blink speed (Text tab's own "Blink speed" field,
+// shown next to "Show a scroll cursor" only while that's on) - stored
+// directly as the frames-per-phase value, always a power of 2 (see
+// buildTextScrollCursorOverride's own blinkMask param above): framecounter's
+// bit for that value is ANDed against every frame, toggling every N frames -
+// a HIGHER value means a SLOWER blink (each on/off phase lasts longer). Only
+// powers of 2 are valid - anything else wouldn't correspond to a single
+// framecounter bit at all. "never" is a special case - not a mask at all,
+// it means the cursor never blinks off (see resolveBlinkMask/
+// buildTextScrollCursorOverride's own "no blink check at all" path below) -
+// first in the list and the default, since a non-blinking cursor is the
+// simpler, less surprising default behavior.
+export const BLINK_SPEED_OPTIONS = [
+  {value: 'never', text: 'Never'},
+  {value: 8, text: '8 frames'},
+  {value: 16, text: '16 frames'},
+  {value: 32, text: '32 frames'},
+  {value: 64, text: '64 frames'},
+  {value: 128, text: '128 frames'},
+];
+export const DEFAULT_BLINK_SPEED = 'never';
+
+// Resolves a stored blink-speed value (config.textScrollCursorBlinkSpeed) to
+// its own "$XX" asm literal, or null for "never"/an unset/invalid value
+// (e.g. an older saved project from before this field existed) - null tells
+// buildTextScrollCursorOverride to skip the blink check entirely rather than
+// AND against some mask, since "never blink" isn't representable as any
+// single framecounter bit.
+export const resolveBlinkMask = (value) => {
+  const option = BLINK_SPEED_OPTIONS.find((o) => o.value === value && typeof o.value === 'number');
+  return option ? '$' + option.value.toString(16).toUpperCase().padStart(2, '0') : null;
+};
+
+/**
+ * Fills in a usable cursor shape - the stored one if it's shaped as
+ * expected, otherwise DEFAULT_TEXT_CURSOR (same "validate shape, else fall
+ * back" pattern as processTextFontDefaults above). Synchronous (unlike
+ * processTextFontDefaults/getDefaultTextFont) - there's no pristine file to
+ * parse a default out of, since this shape never existed in the vendored
+ * text12b.asm at all.
+ * @param {*} storage Text font storage, or its value.
+ * @return {!Array<!Array<number>>} TEXT_CURSOR_HEIGHT x TEXT_CURSOR_WIDTH.
+ */
+export const processCursorGlyphDefaults = (storage) => {
+  const stored = storage && ('value' in storage ? storage.value : storage);
+  const cursor = stored && stored.cursor;
+  const isValid = Array.isArray(cursor) && cursor.length === TEXT_CURSOR_HEIGHT &&
+    cursor.every((row) => Array.isArray(row) && row.length === TEXT_CURSOR_WIDTH);
+  return isValid ? cursor : DEFAULT_TEXT_CURSOR.map((row) => row.slice());
+};
+
+/**
+ * Packs the cursor's own 2x4 pixel matrix into the single byte
+ * buildTextScrollCursorOverride below splices into text12b.asm as a literal
+ * "lda #%XXXXXXXX" - row 0 in the high nibble, row 1 in the low nibble, each
+ * the shape's own full 4 bits wide (see TEXT_CURSOR_WIDTH's own comment for
+ * why this doesn't need left_text/right_text's half-nibble reservation).
+ * @param {!Array<!Array<number>>} cursor TEXT_CURSOR_HEIGHT x TEXT_CURSOR_WIDTH.
+ * @return {string} An assembly "%XXXXXXXX" byte literal.
+ */
+export const packCursorGlyphByte = (cursor) => {
+  const rowBits = (row) => (row || []).map((pixel) => (pixel ? '1' : '0')).join('').padEnd(4, '0');
+  return `%${rowBits(cursor[0])}${rowBits(cursor[1])}`;
+};
+
+const nibbleBits = (row) => row.map((pixel) => pixel ? '1' : '0').join('');
+
+/**
+ * Builds a text12b.asm override with the user's own drawn glyphs spliced
+ * into the left_text/right_text tables, for hooks/rom.js to place as a
+ * sibling of the compiled source (the same mechanism buildScoreFontOverride
+ * in utils/score-font.js already uses for score_graphics.asm). Returns null
+ * whenever nothing has actually been customized yet (no Text Font Editor
+ * card has ever written to storage), or if the bundled text12b.asm isn't
+ * shaped as expected - either way, the caller keeps using the stock,
+ * unmodified file.
+ * @return {!Promise<?string>}
+ */
+export const buildTextFontOverride = async () => {
+  let stored;
+  try {
+    stored = useTextFontStorage().value;
+  } catch (e) {
+    console.error('Error loading the text font from local storage', e);
+    return null;
+  }
+  const glyphs = stored && stored.glyphs;
+  if (!Array.isArray(glyphs) || glyphs.length !== TEXT_GLYPH_COUNT) return null;
+
+  const pristine = await getPristineText12b();
+  const leftStart = findLeftTextStart(pristine);
+  const heightAt = leftStart >= 0 ? pristine.indexOf(HEIGHT_LABEL, leftStart) : -1;
+  const rightStart = heightAt >= 0 ? pristine.indexOf(RIGHT_TABLE_LABEL, heightAt) : -1;
+  if (leftStart < 0 || heightAt < 0 || rightStart < 0) {
+    // The bundled file is not shaped as expected; leave it alone rather than
+    // risk corrupting the ROM layout.
+    return null;
+  }
+
+  // Each glyph's row is a single shared 4-bit pattern - left_text always
+  // stores it left-aligned into the byte's high nibble (the low nibble
+  // always 0), right_text stores that exact same pattern right-aligned into
+  // the low nibble instead (the high nibble always 0) - see this file's own
+  // top comment for why the kernel needs both.
+  const leftValues = [];
+  const rightValues = [];
+  glyphs.forEach((rows) => {
+    rows.forEach((row) => {
+      const bits = nibbleBits(row);
+      leftValues.push(bits + '0000');
+      rightValues.push('0000' + bits);
+    });
+  });
+
+  const leftSection = replaceByteValues(pristine.slice(leftStart, heightAt), leftValues);
+  const rightSection = replaceByteValues(pristine.slice(rightStart), rightValues);
+
+  return pristine.slice(0, leftStart) + leftSection +
+    pristine.slice(heightAt, rightStart) + rightSection;
+};
+
+// A fixed, unique comment text12b.asm itself carries right after
+// "textrowsdone"'s own GRP0/GRP1/NUSIZ0/NUSIZ1/VDELP0/VDELP1 cleanup (see the
+// vendored file directly) - the splice point for the "more below" scroll
+// cursor below. Deliberately NOT a bare "left_text"-style anchor - this text
+// only ever appears once, as a plain comment, so a simple indexOf is safe
+// (no CRLF-vs-LF concern either, since nothing here needs to match ACROSS a
+// line break the way the glyph table anchors do).
+const SCROLL_CURSOR_ANCHOR = 'vcs-game-maker scroll-cursor hook';
+
+// Same reasoning as SCROLL_CURSOR_ANCHOR above, but for row 2's own color -
+// see its own comment in text12b.asm, right after "gotrow2base".
+const ROW2_COLOR_ANCHOR = 'vcs-game-maker row2-color hook';
+
+/**
+ * Splices row 2's own color set into text12b.asm, right after its own fixed
+ * anchor comment (see ROW2_COLOR_ANCHOR above) - a plain "pha/lda <var>/sta
+ * COLUP0/sta COLUP1/pla" run right before row 2's own "jsr showtextrow",
+ * saving/restoring A (row 2's base offset into text_strings, needed
+ * untouched by showtextrow) around the color set. Only ever called when row
+ * 2 is actually used (see hooks/rom.js) - like buildTextScrollCursorOverride
+ * below, there's no separate "customized or not" gate here to return null
+ * from.
+ * @param {string} text12b Either the pristine file, or an earlier override's
+ *     own output - either way, its anchor comment is untouched by that.
+ * @param {{colorVarName: string}} params colorVarName is
+ *     textRow2ColorVarName's own REAL resolved symbol name for this build,
+ *     routed through the ordinary letter/Superchip-var pool (settable via
+ *     the "Text: set row 2 color" block) - see buildTextScrollCursorOverride's
+ *     own doc comment below for why hooks/rom.js has to resolve this rather
+ *     than a standalone util module doing it.
+ * @return {string}
+ */
+export const buildTextRow2ColorOverride = (text12b, {colorVarName}) => {
+  const anchorAt = text12b.indexOf(ROW2_COLOR_ANCHOR);
+  const insertAt = anchorAt >= 0 ? text12b.indexOf('\n', anchorAt) : -1;
+  if (insertAt < 0) {
+    // The bundled file is not shaped as expected; leave it alone rather than
+    // risk corrupting the ROM layout.
+    return text12b;
+  }
+  // $01 is the "never explicitly set" sentinel (see textRow2ColorVarName's
+  // own comment in generators/bbasic/text-minikernel.js) - real color bytes
+  // are always even (colorByteToBBasic masks off bit 0), so $01 can never
+  // collide with an actual chosen color. Row 2 then just follows TextColor
+  // directly until a "Text: set color" block explicitly targets row 2 (or
+  // "both", which still only ever writes TextColor - "both" relies on this
+  // same fallback rather than writing its own copy into row 2's var at
+  // all), including tracking any later change to TextColor (a fade, or
+  // another row-1/both color set) automatically, the way a real single
+  // shared color would.
+  const asm = [
+    '',
+    '        pha',
+    `        lda ${colorVarName}`,
+    '        cmp #$01',
+    '        bne _tr2_use_own',
+    '        lda TextColor',
+    '_tr2_use_own',
+    '        sta COLUP0',
+    '        sta COLUP1',
+    '        pla',
+  ].join('\n');
+  return text12b.slice(0, insertAt) + asm + text12b.slice(insertAt);
+};
+
+/**
+ * Splices the "more below" scroll cursor's own drawing code into
+ * text12b.asm, right after its own fixed anchor comment. Reuses GRP0 on 3
+ * dedicated extra scanlines (a real pixel row, a blank scanline between -
+ * matching how every other glyph in this kernel renders in-game - then the
+ * second real row), the exact same "player0 is already free here" premise
+ * the rest of this kernel already depends on for its real characters. Only
+ * ever called when the feature is actually on (see hooks/rom.js) - unlike
+ * buildTextFontOverride above, there's no separate "customized or not" gate
+ * here to return null from.
+ *
+ * Cycle-exactness (the reason buildTextFontOverride's own glyph edits are
+ * pure byte swaps, never touching code) genuinely doesn't matter for this
+ * one: every new scanline below is its own fresh WSYNC boundary doing only a
+ * handful of cycles' worth of work, with nothing after it depending on a
+ * precise cycle count the way the tight, interleaved character-drawing loop
+ * above it does - if this "spillover" logic (running before its own first
+ * WSYNC) takes a little long, the worst case is quietly consuming one more
+ * invisible overscan-adjacent cycle window, never misaligned pixels.
+ *
+ * @param {string} text12b Either the pristine file, or buildTextFontOverride's
+ *     own output - either way, its anchor comment is untouched by that.
+ * @param {{glyphByte: string, linesMaxVarName: string, linesBaseVarName: string,
+ *     colorVarName: string, endColorVarName: string, blinkMask: string}}
+ *     params glyphByte is a "%XXXXXXXX" literal (see packCursorGlyphByte
+ *     above), reused for both the down arrow (drawn as stored) and the up
+ *     arrow (the same shape, drawn with its two rows swapped - a vertical
+ *     flip, not a separate glyph). linesMaxVarName/linesBaseVarName/
+ *     colorVarName/endColorVarName are _textLinesMax/_textLinesBase/
+ *     textScrollCursorColorVarName/textEndIconColorVarName's own REAL
+ *     resolved symbol names for this build (routed through the ordinary
+ *     letter/Superchip-var pool, never a fixed name - unlike TextIndex/
+ *     TextRow2Active/framecounter, which this can reference directly by
+ *     their own real, unchanging names) - the caller (hooks/rom.js) resolves
+ *     these via Blockly.BBasic.nameDB_ right after the same regenerateCode()
+ *     call that already resolved them for the real generated source, since a
+ *     standalone util module has no live access to that resolver on its own.
+ *     colorVarName/endColorVarName are settable at runtime via the "Text:
+ *     set scroll cursor color"/"Text: set end icon color" blocks, unlike
+ *     glyphByte (fixed once compiled, from the Text Minikernel Font card).
+ *     blinkMask is a "$XX" literal ANDed against framecounter to decide the
+ *     blink phase (see BLINK_SPEED_MASKS below) - a single bit of
+ *     framecounter toggling every N frames, so a HIGHER bit (bigger mask
+ *     value) means a SLOWER blink (each phase lasts longer).
+ * @return {string}
+ */
+export const buildTextScrollCursorOverride = (
+    text12b, {glyphByte, linesMaxVarName, linesBaseVarName, colorVarName, endColorVarName, blinkMask}) => {
+  const anchorAt = text12b.indexOf(SCROLL_CURSOR_ANCHOR);
+  const insertAt = anchorAt >= 0 ? text12b.indexOf('\n', anchorAt) : -1;
+  if (insertAt < 0) {
+    // The bundled file is not shaped as expected; leave it alone rather than
+    // risk corrupting the ROM layout.
+    return text12b;
+  }
+
+  // Both rows' final GRP0 byte only ever depends on two things: the fixed,
+  // compile-time glyph shape (glyphByte - never changes at runtime, only
+  // ever set once from the Text Minikernel Font card) and which of the 4
+  // up/down combinations is currently active (a runtime decision). Since
+  // that's only 4 possibilities, all 4 outcomes per row can be precomputed
+  // right here in JS and stored as a tiny ROM table - replacing the runtime
+  // branch tree (mask/shift/OR, checked by hand earlier for ~45-60 worst-
+  // case cycles per row) with one indexed load (~5 cycles) once the index
+  // itself is built. Table order matches index = (up << 1) | down: [neither
+  // shown, down solo, up solo, both/shared].
+  const parseByteLiteral = (literal) => parseInt(literal.slice(1), 2);
+  const toByteLiteral = (value) => '%' + (value & 0xFF).toString(2).padStart(8, '0');
+  const g = parseByteLiteral(glyphByte);
+  const highNibble = g & 0xF0;
+  const lowNibble = g & 0x0F;
+  // Row 0: up's own contribution (when shown) is the glyph's low nibble
+  // (its stored row 1, for the vertical flip) shifted into the high nibble;
+  // down's is the glyph's high nibble either as-is (solo) or shifted into
+  // the low nibble (shared, alongside up).
+  const row0Table = [
+    0,
+    highNibble,
+    (lowNibble << 4) & 0xFF,
+    ((lowNibble << 4) | (highNibble >> 4)) & 0xFF,
+  ].map(toByteLiteral);
+  // Row 1: the mirror image - up's contribution is the high nibble as-is,
+  // down's is the low nibble either shifted up (solo) or as-is (shared) -
+  // shared for row 1 happens to equal the glyph byte itself unchanged
+  // (high nibble | low nibble = the whole byte).
+  const row1Table = [
+    0,
+    (lowNibble << 4) & 0xFF,
+    highNibble,
+    g,
+  ].map(toByteLiteral);
+
+  // blinkMask null means "never blink" (see resolveBlinkMask above) - the
+  // check itself (not just its mask value) has to be skipped, since there's
+  // no framecounter bit that's "always 1."
+  const blinkCheckLines = (skipLabel) => blinkMask == null ? [] : [
+    '    lda framecounter',
+    `    and #${blinkMask}`,
+    `    beq ${skipLabel}`,
+  ];
+
+  const asm = [
+    '',
+    // Both tables above, skipped over (never executed as code) - referenced
+    // by the indexed loads further down via "lda _tsc_rowN_table,x".
+    '    jmp _tsc_after_tables',
+    '_tsc_row0_table',
+    `    .byte ${row0Table.join(', ')}`,
+    '_tsc_row1_table',
+    `    .byte ${row1Table.join(', ')}`,
+    '_tsc_after_tables',
+    // Down arrow: shown while there's more below to reach with "Scroll text
+    // lines down" - _textLinesMax is already the highest value TextIndex
+    // itself can hold (see setTextLinesRangeCode's own
+    // "lineCount - (wrapToLine2 ? 2 : 1)" formula in generators/bbasic/
+    // text-minikernel.js) - that formula's own "-2" already accounts for
+    // row 2 being shown alongside row 1, so a plain TextIndex/_textLinesMax
+    // compare works the same whether TextRow2Active is set or not.
+    '    ldx #0',
+    '    lda TextIndex',
+    `    cmp ${linesMaxVarName}`,
+    '    bcs _tsc_downdecided',
+    ...blinkCheckLines('_tsc_downdecided'),
+    '    ldx #1',
+    '_tsc_downdecided',
+    '    stx scorepointers+0',
+    // Ends the pre-existing tight scanline (shared with textrowsdone's own
+    // cleanup) right where the original single-arrow version always did -
+    // everything below runs on its own fresh scanlines instead of adding
+    // more work here, since this one has no slack to spare (an earlier
+    // attempt at extra precompute work here caused real frame-timing
+    // corruption - see this function's own history).
+    '    sta WSYNC',
+    // The end icon's own flag - deliberately NOT the same as the down
+    // arrow's own scorepointers+0 (which also blinks off while there's
+    // still more below, same on/off cycle the arrow itself uses) - the end
+    // icon needs a steady "is there structurally nothing left" check with
+    // no blink mixed in, or it would flicker on during the down arrow's own
+    // off phase even with more content still left to scroll to (a real
+    // reported bug). Reuses the carry flag from the down-decision's own
+    // "cmp linesMaxVarName" above (the SAME comparison) instead of redoing
+    // it - nothing between there and here touches carry (LDA/AND/branches/
+    // LDX/STX/a plain STA WSYNC all leave it alone), so it's still exactly
+    // "TextIndex >= linesMax" from that original compare.
+    '    ldx #1',
+    '    bcc _tsc_hasmore_far',
+    '    ldx #0',
+    '_tsc_hasmore_far',
+    '    stx scorepointers+5',
+    // Up arrow: shown while there's more above to reach with "Scroll text
+    // lines up" - _textLinesBase is the lowest value TextIndex can hold for
+    // the message currently shown, so TextIndex is only ever equal to it
+    // (nothing more above) or greater (more above).
+    '    ldx #0',
+    '    lda TextIndex',
+    `    cmp ${linesBaseVarName}`,
+    '    beq _tsc_updecided',
+    ...blinkCheckLines('_tsc_updecided'),
+    '    ldx #1',
+    '_tsc_updecided',
+    '    stx scorepointers+1',
+    // Both rows' final GRP0 byte is now a single table lookup (see
+    // row0Table/row1Table above) instead of a branch tree - just needs a
+    // 2-bit index built from the up/down flags: (up << 1) | down, matching
+    // each table's own [neither, down solo, up solo, shared] order. Cheap
+    // enough to compute right here alongside the up-decision, rather than
+    // needing its own dedicated scanline the way the old branchy version
+    // did. Left in X (not stashed to scratch RAM) - nothing between here and
+    // the indexed loads below touches X, and WSYNC itself never touches any
+    // CPU register, so it survives the scanline boundary for free.
+    '    lda scorepointers+1',
+    '    asl',
+    '    ora scorepointers+0',
+    '    tax',
+    '    sta WSYNC',
+    // GRP1 sits ~10 color clocks right of GRP0 by default (RESP1 strobes 3
+    // CPU cycles after RESP0, plus a 1-clock difference between HMP0/HMP1's
+    // own original fine-adjust) - an earlier version corrected this with an
+    // HMCLR/HMP1/HMOVE sequence, but HMOVE applying any nonzero motion
+    // causes a real, unavoidable "comb" glitch (a black patch on that
+    // scanline's left edge). A plain RESP1 re-strobe, on its own dedicated
+    // scanline, moves it instead without touching any HM register at all -
+    // no glitch, just coarser control (3-pixel/1-CPU-cycle steps, since
+    // that's what one fewer cycle of "sleep" before the strobe buys) rather
+    // than HMOVE's single-pixel fine adjustment. The exact same cycle offset
+    // from a fresh WSYNC always lands on the same physical screen column
+    // regardless of which scanline it's on - "sleep 45" here reproduces
+    // roughly the same column minikernel's own original RESP1 strobe did
+    // (cycle 46 there, see text12a.asm), one cycle (3 pixels) earlier to
+    // nudge it left.
+    '    sleep 40',
+    '    sta RESP1',
+    '    sta WSYNC',
+    // Both rows' table lookups (same index, still in X from before - see
+    // its own comment above), the end icon's own byte, and both colors -
+    // all still comfortably inside one scanline's budget now that the old
+    // branch trees are gone.
+    '    lda _tsc_row0_table,x',
+    '    sta scorepointers+2',
+    '    lda _tsc_row1_table,x',
+    '    sta scorepointers+3',
+    // The end icon's own byte (GRP1, shared by both rows - a plain filled
+    // square, same shape either row) - shown whenever there's structurally
+    // nothing left below (scorepointers+5 - see its own comment above;
+    // deliberately not the down arrow's own blinking flag).
+    '    lda #0',
+    '    ldx scorepointers+5',
+    '    cpx #0',
+    '    bne _tsc_endzero',
+    `    lda #${END_ICON_BYTE}`,
+    '_tsc_endzero',
+    '    sta scorepointers+4',
+    // The cursor's own color ("Text: set scroll cursor color" block) and
+    // the end icon's own ("Text: set end icon color") - COLUP0/COLUP1 stay
+    // put across scanlines until something else writes them, so setting
+    // them here (rather than on the draw scanlines themselves) costs
+    // nothing extra there.
+    `    lda ${colorVarName}`,
+    '    sta COLUP0',
+    `    lda ${endColorVarName}`,
+    '    sta COLUP1',
+    '    sta WSYNC',
+    // Row 0 draw: plain bare loads/stores, same fast timing the original
+    // single-arrow version always used - no HMOVE needed (see this
+    // function's own history for why GRP1 is left at its natural position).
+    '    lda scorepointers+2',
+    '    sta GRP0',
+    '    lda scorepointers+4',
+    '    sta GRP1',
+    '    sta WSYNC',
+    '    lda #0',
+    '    sta GRP0',
+    '    sta GRP1',
+    '    sta WSYNC',
+    // Row 1 draw: likewise bare.
+    '    lda scorepointers+3',
+    '    sta GRP0',
+    '    lda scorepointers+4',
+    '    sta GRP1',
+    // Row 1's write can leave GRP0/GRP1 holding a nonzero shape - nothing
+    // else clears them before whatever draws next (e.g. a top-of-screen
+    // status area also using GRP0/GRP1), so without this it can smear the
+    // cursor's leftover pixels into that unrelated drawing until the next
+    // frame's own gameplay code re-establishes them from scratch. Needs its
+    // own fresh WSYNC first - without one, this zero-write happens on the
+    // very same scanline as row 1's own draw above, stomping it before the
+    // beam even finishes sweeping across that line (row 1 never actually
+    // became visible - only row 0 did).
+    '    sta WSYNC',
+    '    lda #0',
+    '    sta GRP0',
+    '    sta GRP1',
+  ].join('\n');
+
+  return text12b.slice(0, insertAt) + asm + text12b.slice(insertAt);
+};

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -464,18 +464,31 @@ export default defineComponent({
           // The user closing/cancelling the picker throws AbortError -
           // not a real failure, nothing to report or recover from.
           if (e && e.name === 'AbortError') return;
-          console.error('Error while saving project', e);
+          // Chrome throws this SecurityError unconditionally when the app
+          // is embedded in a cross-origin iframe - the spec disallows the
+          // picker there outright, with no permissions-policy/allow
+          // attribute able to override it (confirmed as the actual
+          // reported bug: "Save"/"Save As" silently doing nothing when
+          // embedded that way). Falls through to the same download-based
+          // fallback used on a browser that never had the File System
+          // Access API at all, rather than leaving the user with no way
+          // to save.
+          if (!(e && e.name === 'SecurityError')) {
+            console.error('Error while saving project', e);
+            return;
+          }
+        }
+        if (handle) {
+          const writable = await handle.createWritable();
+          await writable.write(projectYaml);
+          await writable.close();
+          this.data.activeFileHandle = handle;
+          // So "Save" keeps working as "Save" after a reload too - see
+          // utils/file-handle-storage.js's own comment.
+          persistActiveFileHandle(handle);
+          appendCompileLog(`Game saved to ${handle.name}`, 'stage');
           return;
         }
-        const writable = await handle.createWritable();
-        await writable.write(projectYaml);
-        await writable.close();
-        this.data.activeFileHandle = handle;
-        // So "Save" keeps working as "Save" after a reload too - see
-        // utils/file-handle-storage.js's own comment.
-        persistActiveFileHandle(handle);
-        appendCompileLog(`Game saved to ${handle.name}`, 'stage');
-        return;
       }
 
       const projectBlob = new Blob([projectYaml], {type: 'text/yaml'});
@@ -591,7 +604,14 @@ export default defineComponent({
           handles = await window.showOpenFilePicker({types: FILE_PICKER_TYPES});
         } catch (e) {
           if (e && e.name === 'AbortError') return;
-          console.error('Error while opening project', e);
+          // Same cross-origin-iframe SecurityError as handleSaveProjectAs
+          // above - falls through to the plain file input below instead of
+          // leaving "Open Project" dead in that context.
+          if (!(e && e.name === 'SecurityError')) {
+            console.error('Error while opening project', e);
+            return;
+          }
+          this.$refs.importFileInput.click();
           return;
         }
         const [handle] = handles;

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -144,11 +144,11 @@ import {defineComponent, reactive, computed, onMounted} from '@vue/composition-a
 import {saveAs} from 'file-saver';
 import YAML from 'yaml';
 
-import {appendCompileLog, useBackgroundsStorage, useConfigurationStorage, useDataTablesStorage, usePlayer0Storage, usePlayer1Storage, useProjectAutoIncrementVersionStorage, useScoreFontStorage, useSongsStorage, useSoundEffectsStorage, useSquishCustomScoreFontStorage, useTextStringsStorage, useWorkspaceStorage} from '../hooks/project';
+import {appendCompileLog, useBackgroundsStorage, useConfigurationStorage, useDataTablesStorage, usePlayer0Storage, usePlayer1Storage, useProjectAutoIncrementVersionStorage, useScoreFontStorage, useSongsStorage, useSoundEffectsStorage, useSquishCustomScoreFontStorage, useTextFontStorage, useTextStringsStorage, useWorkspaceStorage} from '../hooks/project';
 import {getDateInfix} from '../utils/date';
 import {resetMusicEditorActiveState} from '../hooks/music-editor-state';
 import {matrixToPlayfield, playfieldToMatrix} from '../utils/pixels';
-import {persistActiveFileHandle, loadPersistedFileHandle, ensureWritePermission} from '../utils/file-handle-storage';
+import {persistActiveFileHandle, loadPersistedFileHandle, ensureWritePermission, persistActiveFilePath, loadPersistedFilePath} from '../utils/file-handle-storage';
 import {version as appVersion} from '../../package.json';
 
 const FORMAT_TYPE = 'VCS Game Maker Project';
@@ -167,6 +167,17 @@ const SUPPORTS_FILE_SYSTEM_ACCESS =
   typeof window !== 'undefined' &&
   typeof window.showSaveFilePicker === 'function' &&
   typeof window.showOpenFilePicker === 'function';
+
+// window.electronAPI only exists inside the desktop build's preload script
+// (see preload.js) - never true in a browser. Checked BEFORE
+// SUPPORTS_FILE_SYSTEM_ACCESS in every save/open handler below: Electron
+// never exposes window.showSaveFilePicker/showOpenFilePicker (that API
+// isn't wired up in Electron the way it is in Chrome), so without this,
+// SUPPORTS_FILE_SYSTEM_ACCESS was always false there and "Save" silently
+// fell all the way back to "Save As..." - a picker on every single click,
+// even for the same already-saved file (a real reported bug: "Save" acting
+// like "Save As" in the desktop build).
+const IS_ELECTRON = typeof window !== 'undefined' && !!window.electronAPI;
 
 const FILE_PICKER_TYPES = [{
   description: 'VCS Game Maker Project',
@@ -195,6 +206,13 @@ export default defineComponent({
       // even with the exact same project still open, since a
       // FileSystemFileHandle used to live in memory only.
       activeFileHandle: null,
+      // The Electron build's own equivalent of activeFileHandle above - a
+      // plain absolute path (see background.js's project:save-as/
+      // project:open handlers) rather than a FileSystemFileHandle, since
+      // Electron never exposes the File System Access API SUPPORTS_FILE_
+      // SYSTEM_ACCESS checks for. Restored from localStorage on mount (see
+      // onMounted below), same reasoning as activeFileHandle's own restore.
+      activeFilePath: null,
     });
     const router = context.root.$router;
 
@@ -207,6 +225,7 @@ export default defineComponent({
     const squishCustomScoreFontStorage = useSquishCustomScoreFontStorage();
     const dataTablesStorage = useDataTablesStorage();
     const textStringsStorage = useTextStringsStorage();
+    const textFontStorage = useTextFontStorage();
     const soundEffectsStorage = useSoundEffectsStorage();
     const songsStorage = useSongsStorage();
 
@@ -268,9 +287,26 @@ export default defineComponent({
       });
     }
 
+    // Electron's own restore - the file may have been moved/deleted since
+    // the path was persisted, so this double-checks via project:path-exists
+    // (the Electron-side equivalent of the browser restore's own
+    // queryPermission() === 'denied' check above) rather than trusting a
+    // stale path and only finding out on the next failed Save.
+    if (IS_ELECTRON) {
+      onMounted(async () => {
+        const filePath = loadPersistedFilePath();
+        if (!filePath) return;
+        try {
+          if (await window.electronAPI.projectPathExists(filePath)) data.activeFilePath = filePath;
+        } catch (e) {
+          console.error('Error while checking the restored project file path', e);
+        }
+      });
+    }
+
     return {data, router, backgroundsStorage, player0Storage, player1Storage,
       workspaceStorage, configurationStorage, scoreFontStorage, squishCustomScoreFontStorage, dataTablesStorage,
-      textStringsStorage, soundEffectsStorage, songsStorage, projectTitle, projectDescription,
+      textStringsStorage, textFontStorage, soundEffectsStorage, songsStorage, projectTitle, projectDescription,
       projectDeveloper, projectVersion, projectAutoIncrementVersion, projectWebsite, projectEmail};
   },
   methods: {
@@ -327,6 +363,17 @@ export default defineComponent({
         digits: this.squishCustomScoreFontStorage.digits.map(matrixToPlayfield),
       };
 
+      const textFont = !this.textFontStorage ? null : {
+        ...this.textFontStorage,
+        glyphs: this.textFontStorage.glyphs.map(matrixToPlayfield),
+        // The scroll cursor's own shape (see components/TextFontEditor.vue) -
+        // optional: an older saved project (or one that's never opened the
+        // Text Font Editor card at all) has no cursor of its own yet, and
+        // processCursorGlyphDefaults already falls back to a sensible
+        // default whenever this key is missing on load.
+        cursor: this.textFontStorage.cursor ? matrixToPlayfield(this.textFontStorage.cursor) : undefined,
+      };
+
       const projectYaml = YAML.stringify({
         'type': FORMAT_TYPE,
         'format-version': FORMAT_VERSION,
@@ -348,6 +395,7 @@ export default defineComponent({
         'squish-custom-score-font': squishCustomScoreFont,
         'data-tables': this.dataTablesStorage,
         'text-strings': this.textStringsStorage,
+        'text-font': textFont,
         'sound-effects': this.soundEffectsStorage,
         // Songs, sequences, patterns, instruments (tracks) and their notes -
         // all live in this one storage object (see hooks/project.js's
@@ -396,6 +444,15 @@ export default defineComponent({
       const projectYaml = this.buildProjectYaml();
       const filename = this.buildSaveFilename();
 
+      if (IS_ELECTRON) {
+        const result = await window.electronAPI.saveProjectAs(projectYaml, filename);
+        if (!result) return; // The user cancelled the native dialog.
+        this.data.activeFilePath = result.path;
+        persistActiveFilePath(result.path);
+        appendCompileLog(`Game saved to ${result.path}`, 'stage');
+        return;
+      }
+
       if (SUPPORTS_FILE_SYSTEM_ACCESS) {
         let handle;
         try {
@@ -435,6 +492,24 @@ export default defineComponent({
     // meaning Save always does SOMETHING useful, and every save after that
     // first one goes straight back to the same file with no prompt.
     async handleSaveProject() {
+      if (IS_ELECTRON) {
+        if (!this.data.activeFilePath) {
+          await this.handleSaveProjectAs();
+          return;
+        }
+        if (this.projectAutoIncrementVersion) {
+          this.projectVersion = this.incrementVersion(this.projectVersion);
+        }
+        const projectYaml = this.buildProjectYaml();
+        const ok = await window.electronAPI.saveProject(this.data.activeFilePath, projectYaml);
+        if (!ok) {
+          console.error('Could not save the project file.');
+          return;
+        }
+        appendCompileLog(`Game saved to ${this.data.activeFilePath}`, 'stage');
+        return;
+      }
+
       if (!SUPPORTS_FILE_SYSTEM_ACCESS || !this.data.activeFileHandle) {
         await this.handleSaveProjectAs();
         return;
@@ -501,6 +576,15 @@ export default defineComponent({
     // that way, since there's no way to silently write back to a file
     // picked through a plain <input type="file">.
     async handleOpenProjectClick() {
+      if (IS_ELECTRON) {
+        const result = await window.electronAPI.openProject();
+        if (!result) return; // The user cancelled the native dialog.
+        this.data.activeFilePath = result.path;
+        persistActiveFilePath(result.path);
+        this.applyProjectYaml(result.content, result.name);
+        return;
+      }
+
       if (SUPPORTS_FILE_SYSTEM_ACCESS) {
         let handles;
         try {
@@ -545,112 +629,126 @@ export default defineComponent({
 
       const reader = new FileReader();
       reader.readAsText(file, 'UTF-8');
-      reader.onload = (evt) => {
-        const projectYaml = evt.target.result;
-        console.info('YAML', projectYaml);
-        // YAML.parse returns null (not a parse error) for an empty document
-        // - an empty/blank file, or one that's otherwise valid YAML but
-        // just isn't an object (e.g. a bare "null"/"~" or a single scalar
-        // value) - confirmed as a real reported crash this way: unguarded,
-        // "project.type" below threw "Cannot read properties of null
-        // (reading 'type')", a confusing raw TypeError instead of this same
-        // file's own clear "not a valid project" message every OTHER
-        // malformed-file case already gets.
-        const project = YAML.parse(projectYaml);
-        if (!project || typeof project !== 'object') {
-          throw new Error('This file does not seem to be a valid project.');
-        }
-
-        if (project.type !== FORMAT_TYPE) {
-          throw new Error('This file does not seem to be a valid project.');
-        }
-
-        if (project['format-version'] > FORMAT_VERSION) {
-          throw new Error(
-              `This project's version (${project['format-version']}) is newer than the supported version (${FORMAT_VERSION})`);
-        }
-
-        this.workspaceStorage = project['blockly-workspace'];
-
-        const preparePlayerLoad = (playerData) => playerData && {
-          ...playerData,
-          animations: playerData.animations.map((animation) => ({
-            ...animation,
-            frames: animation.frames.map((frame) => ({
-              ...frame,
-              pixels: playfieldToMatrix(frame.pixels),
-            })),
-          })),
-        };
-
-        const player0 = preparePlayerLoad(project['player-0']);
-        if (player0) {
-          this.player0Storage = player0;
-        }
-
-        const player1 = preparePlayerLoad(project['player-1']);
-        if (player1) {
-          this.player1Storage = player1;
-        }
-
-        if (project['score-font']) {
-          this.scoreFontStorage = {
-            ...project['score-font'],
-            digits: project['score-font'].digits.map(playfieldToMatrix),
-          };
-        }
-
-        if (project['squish-custom-score-font']) {
-          this.squishCustomScoreFontStorage = {
-            ...project['squish-custom-score-font'],
-            digits: project['squish-custom-score-font'].digits.map(playfieldToMatrix),
-          };
-        }
-
-        if (project.backgrounds) {
-          const backgrounds = {
-            ...project.backgrounds,
-            backgrounds: project.backgrounds.backgrounds
-                .map((bkg) => ({...bkg, pixels: playfieldToMatrix(bkg.pixels)})),
-          };
-          this.backgroundsStorage = backgrounds;
-        }
-
-        if (project.configuration) {
-          this.configurationStorage = project.configuration;
-        }
-
-        if (project['data-tables']) {
-          this.dataTablesStorage = project['data-tables'];
-        }
-
-        if (project['text-strings']) {
-          this.textStringsStorage = project['text-strings'];
-        }
-
-        if (project['sound-effects']) {
-          this.soundEffectsStorage = project['sound-effects'];
-        }
-
-        if (project.songs) {
-          this.songsStorage = project.songs;
-        }
-
-        // Song/pattern/track IDs in the loaded project collide with
-        // whatever the previous project used (both start counting from 1) -
-        // without this, the Music tab's own active pattern/track selection
-        // (see hooks/music-editor-state.js) would keep pointing at IDs left
-        // over from before, showing the piano roll against the wrong
-        // pattern/track, or one that doesn't exist in this project at all.
-        resetMusicEditorActiveState();
-        // Unlike an earlier version of this, deliberately stays on this tab
-        // rather than navigating to Actions - same reasoning as
-        // handleNewProject's own identical change: the user may still want
-        // to check/adjust the imported project's own Title/Developer/
-        // Version/Description right here first.
-        appendCompileLog(`Imported project ${file.name}`, 'stage');
-      };
+      reader.onload = (evt) => this.applyProjectYaml(evt.target.result, file.name);
       reader.onerror = (evt) => console.error('Error while loading project', evt);
+    },
+
+    // Shared by loadProjectFromFile (FileReader-based, used by the browser
+    // build's own File System Access/plain-input paths) and Electron's
+    // handleOpenProjectClick above, which already has the file's content as
+    // a plain string via IPC (fs.readFileSync in the main process) with no
+    // File/FileReader involved at all.
+    applyProjectYaml(projectYaml, sourceName) {
+      console.info('YAML', projectYaml);
+      // YAML.parse returns null (not a parse error) for an empty document
+      // - an empty/blank file, or one that's otherwise valid YAML but
+      // just isn't an object (e.g. a bare "null"/"~" or a single scalar
+      // value) - confirmed as a real reported crash this way: unguarded,
+      // "project.type" below threw "Cannot read properties of null
+      // (reading 'type')", a confusing raw TypeError instead of this same
+      // file's own clear "not a valid project" message every OTHER
+      // malformed-file case already gets.
+      const project = YAML.parse(projectYaml);
+      if (!project || typeof project !== 'object') {
+        throw new Error('This file does not seem to be a valid project.');
+      }
+
+      if (project.type !== FORMAT_TYPE) {
+        throw new Error('This file does not seem to be a valid project.');
+      }
+
+      if (project['format-version'] > FORMAT_VERSION) {
+        throw new Error(
+            `This project's version (${project['format-version']}) is newer than the supported version (${FORMAT_VERSION})`);
+      }
+
+      this.workspaceStorage = project['blockly-workspace'];
+
+      const preparePlayerLoad = (playerData) => playerData && {
+        ...playerData,
+        animations: playerData.animations.map((animation) => ({
+          ...animation,
+          frames: animation.frames.map((frame) => ({
+            ...frame,
+            pixels: playfieldToMatrix(frame.pixels),
+          })),
+        })),
+      };
+
+      const player0 = preparePlayerLoad(project['player-0']);
+      if (player0) {
+        this.player0Storage = player0;
+      }
+
+      const player1 = preparePlayerLoad(project['player-1']);
+      if (player1) {
+        this.player1Storage = player1;
+      }
+
+      if (project['score-font']) {
+        this.scoreFontStorage = {
+          ...project['score-font'],
+          digits: project['score-font'].digits.map(playfieldToMatrix),
+        };
+      }
+
+      if (project['squish-custom-score-font']) {
+        this.squishCustomScoreFontStorage = {
+          ...project['squish-custom-score-font'],
+          digits: project['squish-custom-score-font'].digits.map(playfieldToMatrix),
+        };
+      }
+
+      if (project.backgrounds) {
+        const backgrounds = {
+          ...project.backgrounds,
+          backgrounds: project.backgrounds.backgrounds
+              .map((bkg) => ({...bkg, pixels: playfieldToMatrix(bkg.pixels)})),
+        };
+        this.backgroundsStorage = backgrounds;
+      }
+
+      if (project.configuration) {
+        this.configurationStorage = project.configuration;
+      }
+
+      if (project['data-tables']) {
+        this.dataTablesStorage = project['data-tables'];
+      }
+
+      if (project['text-strings']) {
+        this.textStringsStorage = project['text-strings'];
+      }
+
+      if (project['text-font']) {
+        this.textFontStorage = {
+          ...project['text-font'],
+          glyphs: project['text-font'].glyphs.map(playfieldToMatrix),
+          cursor: project['text-font'].cursor ? playfieldToMatrix(project['text-font'].cursor) : undefined,
+        };
+      }
+
+      if (project['sound-effects']) {
+        this.soundEffectsStorage = project['sound-effects'];
+      }
+
+      if (project.songs) {
+        this.songsStorage = project.songs;
+      }
+
+      // Song/pattern/track IDs in the loaded project collide with
+      // whatever the previous project used (both start counting from 1) -
+      // without this, the Music tab's own active pattern/track selection
+      // (see hooks/music-editor-state.js) would keep pointing at IDs left
+      // over from before, showing the piano roll against the wrong
+      // pattern/track, or one that doesn't exist in this project at all.
+      resetMusicEditorActiveState();
+      // Unlike an earlier version of this, deliberately stays on this tab
+      // rather than navigating to Actions - same reasoning as
+      // handleNewProject's own identical change: the user may still want
+      // to check/adjust the imported project's own Title/Developer/
+      // Version/Description right here first.
+      appendCompileLog(`Imported project ${sourceName}`, 'stage');
     },
 
     handleNewProject() {
@@ -668,7 +766,12 @@ export default defineComponent({
       // the old project's handle right back onto this new, unrelated one.
       this.data.activeFileHandle = null;
       persistActiveFileHandle(null);
+      // The Electron build's own equivalent of the above - see
+      // data.activeFilePath's own comment in setup().
+      this.data.activeFilePath = null;
+      persistActiveFilePath(null);
       this.textStringsStorage = null;
+      this.textFontStorage = null;
       this.soundEffectsStorage = null;
       this.songsStorage = null;
 

--- a/src/views/ScoreFontEditor.vue
+++ b/src/views/ScoreFontEditor.vue
@@ -34,14 +34,24 @@
         to edit here.
       </p>
       <template v-if="isEditableFontSelected">
-        <v-switch
-          v-if="showExtraGlyphs"
-          v-model="extraGlyphsEnabled"
-          label="Use extra glyphs (10-15)"
-          hint="Costs 48 extra bytes of ROM space."
-          persistent-hint
-          class="option-switch"
-        />
+        <div class="score-extras-row">
+          <v-switch
+            v-if="showExtraGlyphs"
+            v-model="extraGlyphsEnabled"
+            label="Use extra glyphs (10-15)"
+            hint="Costs 48 extra bytes of ROM space."
+            persistent-hint
+            class="option-switch"
+          />
+          <v-select
+            v-model="scorePaddingLines"
+            :items="[0, 1, 2]"
+            label="Add score padding"
+            title="How many extra scanlines of the score row's own background color to draw right after the score digits finish, before whatever draws next."
+            hide-details
+            class="score-padding-field"
+          />
+        </div>
         <editor-zoom v-model="zoom" class="score-editor-zoom" />
         <div class="digit-list">
           <div
@@ -284,6 +294,30 @@ export default defineComponent({
         };
       },
     });
+    // How many extra blank scanlines (0, 1, or 2) the score row draws of its
+    // own background color right after the digits finish (see
+    // generators/bbasic.js's own scorePaddingConfigurationCode, which emits
+    // "const scorepaddinglines = N" - text12a.asm's own
+    // "if scorepaddinglines >= N" checks read that). 0 by default - a
+    // project that's never visited this dropdown keeps its existing frame
+    // timing unchanged.
+    const scorePaddingLines = computed({
+      get() {
+        try {
+          const value = (configurationStorage.value || {}).scorePaddingLines;
+          return value == null ? 0 : value;
+        } catch (e) {
+          console.error('Error loading configuration from local storage', e);
+          return 0;
+        }
+      },
+      set(value) {
+        configurationStorage.value = {
+          ...(configurationStorage.value || {}),
+          scorePaddingLines: value,
+        };
+      },
+    });
     const activeScoreFontStorage = computed(() =>
       isSquishCustomSelected.value ? squishCustomScoreFontStorage : scoreFontStorage);
     const activeDefaultFont = computed(() =>
@@ -345,6 +379,7 @@ export default defineComponent({
       digitWidth,
       showExtraGlyphs,
       extraGlyphsEnabled,
+      scorePaddingLines,
       isEditableFontSelected,
       DECIMAL_DIGIT_COUNT,
     };
@@ -357,6 +392,16 @@ export default defineComponent({
    under the label text instead, matching the toggle's own width. */
 .option-switch >>> .v-messages {
   margin-left: 46px;
+}
+
+.score-extras-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.score-padding-field {
+  max-width: 200px;
 }
 
 /* Breathing room from the "Use extra glyphs" switch's own hint text

--- a/src/views/TextEditor.vue
+++ b/src/views/TextEditor.vue
@@ -3,15 +3,13 @@
     <v-card class="editor-container" :ripple="false" @click="deselectCard">
       <v-card-title>Text</v-card-title>
       <v-card-text>
-        <p class="v-messages theme--light v-messages__message">
-          Define named messages here, then display one at runtime with either the "Show text"
-          block (pick from a list) or "Show text ID" (pick by the number shown below - useful
-          for choosing a message from a variable). A-Z, 0-9, and basic punctuation only -
-          unsupported characters and shorter text are padded with spaces. Use the "(scrolling)"
-          versions of the "Show text" blocks to reveal a message longer than 12 characters by
-          scrolling through it, or turn on a message's own "Wrap to line 2" below to word-wrap
-          it onto a second static line instead - the max display width below does not apply to
-          either.
+        <p class="v-messages theme--light v-messages__message text-intro-paragraph">
+          Define text blocks here, then display them at runtime with either the "Show text"
+          block (pick from a list) or "Show text ID" - useful for choosing a message from a
+          variable. A-Z, 0-9, and basic punctuation only. Unsupported characters and shorter
+          text are padded with spaces. Use the "(scrolling)" versions of the "Show text" blocks
+          to reveal a message longer than 12 characters by scrolling through it, or turn on a
+          message's "Multiline" for word-wrap onto a second static line instead.
         </p>
 
         <div class="text-bkcolor-row">
@@ -23,6 +21,29 @@
           />
           <span class="text-bkcolor-label">Text background color</span>
         </div>
+
+        <div class="text-bkcolor-row">
+          <v-switch
+            v-model="enableTextScrollCursor"
+            label="Show a scroll cursor"
+            title="Shows a small indicator (edit its shape in the Text Minikernel Font card below) right after whichever row is currently the last one visible, but only while there's more of the message left to reveal with &quot;Scroll text lines down&quot;. Costs a few extra scanlines whenever this is on, regardless of whether any particular message actually needs it."
+            hide-details
+            class="text-scroll-cursor-switch"
+          />
+          <v-select
+            v-if="enableTextScrollCursor"
+            v-model="textScrollCursorBlinkSpeed"
+            :items="BLINK_SPEED_OPTIONS"
+            item-text="text"
+            item-value="value"
+            title="How often the cursor blinks off - always a power of 2 number of frames (a single framecounter bit), or Never for a steady, non-blinking cursor"
+            label="Blink speed"
+            hide-details
+            class="text-blink-speed-field"
+          />
+        </div>
+
+        <text-font-editor />
 
         <div class="text-max-width-row">
           <v-select
@@ -40,7 +61,7 @@
             class="text-columns-switch"
           />
         </div>
-        <p class="v-messages theme--light v-messages__message">
+        <p class="v-messages theme--light v-messages__message text-max-width-help">
           For static (non-scrolling) text only. Only the first this-many of the 12 available character
           slots are ever used - the rest always stay blank, regardless of message length or justify. The
           "Scroll text" blocks ignore this and always scroll through the full message using
@@ -131,10 +152,11 @@
                   <v-textarea
                     label="Text"
                     v-model="entry.text"
-                    :counter="entry.wrapToLine2 ? 24 : 12"
+                    :counter="entry.wrapToLine2 ? TEXT_CARD_MAX_LENGTH : 12"
+                    :maxlength="TEXT_CARD_MAX_LENGTH"
                     outlined
                     rows="2"
-                    hint="Press Enter for a line break - only takes effect with &quot;Wrap to line 2&quot; on below; otherwise it's treated as a space. More than 2 lines: use the &quot;Scroll text lines&quot; blocks to move through them at runtime."
+                    :hint="`Press Enter for a line break. More than 2 lines (or no room for a 2nd - see &quot;Multiline&quot; below): use the &quot;Scroll text lines&quot; blocks to move through them at runtime. ${TEXT_CARD_MAX_LENGTH} characters max.`"
                     persistent-hint
                     @change="() => handleTextChange(entry)"
                   />
@@ -157,8 +179,8 @@
                   </v-btn-toggle>
                   <v-switch
                     v-model="entry.wrapToLine2"
-                    label="Wrap to line 2"
-                    title="When this message is longer than 12 characters, word-wrap the overflow onto a second 12-character line underneath, instead of cutting it off. Only the plain &quot;Show text&quot; blocks support this - the &quot;(scrolling)&quot; blocks always scroll a single line and ignore it."
+                    label="Multiline"
+                    title="When this message is longer than 12 characters, shows its second line automatically underneath the first, with no scrolling needed. Off (or for a message with more than 2 lines), only the first line shows until a &quot;Scroll text lines&quot; block is used to reveal the rest. Only the plain &quot;Show text&quot; blocks support this - the &quot;(scrolling)&quot; blocks always scroll a single line and ignore it."
                     hide-details
                     dense
                     class="text-wrap-switch"
@@ -191,14 +213,17 @@ import {computed, defineComponent, getCurrentInstance, ref} from '@vue/compositi
 import {max} from 'lodash';
 
 import ColorSwatchPicker from '../components/ColorSwatchPicker.vue';
+import TextFontEditor from '../components/TextFontEditor.vue';
 import {useCollapsedIds} from '../hooks/collapse';
 import {CSS_CLASS_DRAGGING} from '../hooks/drag-reorder';
 import {useConfigurationStorage, useTextStringsStorage, useTextColumnsStorage} from '../hooks/project';
 import {DEFAULT_TEXT_JUSTIFY, DEFAULT_TEXT_STRINGS, DEFAULT_TEXT_MAX_DISPLAY_WIDTH,
-  TEXT_MAX_DISPLAY_WIDTH_OPTIONS, processTextStringsStorageDefaults} from '../blocks/text-strings';
+  TEXT_MAX_DISPLAY_WIDTH_OPTIONS, TEXT_CARD_MAX_LENGTH,
+  processTextStringsStorageDefaults} from '../blocks/text-strings';
+import {BLINK_SPEED_OPTIONS, DEFAULT_BLINK_SPEED} from '../utils/text-font';
 
 export default defineComponent({
-  components: {ColorSwatchPicker},
+  components: {ColorSwatchPicker, TextFontEditor},
   setup() {
     const textStringsStorage = useTextStringsStorage();
     const configurationStorage = useConfigurationStorage();
@@ -225,6 +250,51 @@ export default defineComponent({
         configurationStorage.value = {
           ...(configurationStorage.value || {}),
           textBkColor: value,
+        };
+      },
+    });
+
+    // Whether text12b.asm's own "more below" scroll cursor is compiled in at
+    // all (see generators/bbasic.js's own buildRom-time
+    // buildTextScrollCursorOverride splice, gated on this same field) - a
+    // single project-wide toggle, same reasoning/pattern as textBkColor
+    // just above.
+    const enableTextScrollCursor = computed({
+      get() {
+        try {
+          return !!(configurationStorage.value || {}).enableTextScrollCursor;
+        } catch (e) {
+          console.error('Error loading configuration from local storage', e);
+          return false;
+        }
+      },
+
+      set(value) {
+        configurationStorage.value = {
+          ...(configurationStorage.value || {}),
+          enableTextScrollCursor: value,
+        };
+      },
+    });
+
+    // The scroll cursor's own blink speed (see BLINK_SPEED_OPTIONS/
+    // resolveBlinkMask in utils/text-font.js) - only meaningful (and only
+    // shown, see the template above) while enableTextScrollCursor is on.
+    const textScrollCursorBlinkSpeed = computed({
+      get() {
+        try {
+          const value = (configurationStorage.value || {}).textScrollCursorBlinkSpeed;
+          return value == null ? DEFAULT_BLINK_SPEED : value;
+        } catch (e) {
+          console.error('Error loading configuration from local storage', e);
+          return DEFAULT_BLINK_SPEED;
+        }
+      },
+
+      set(value) {
+        configurationStorage.value = {
+          ...(configurationStorage.value || {}),
+          textScrollCursorBlinkSpeed: value,
         };
       },
     });
@@ -410,8 +480,9 @@ export default defineComponent({
     return {
       selectedCardId, selectCard, deselectCard,
       state, handleChildChange, handleAddEntry, handleDeleteEntry, handleTextChange,
-      isCollapsed, toggleCollapsed, textBkColor, textMaxDisplayWidth, TEXT_MAX_DISPLAY_WIDTH_OPTIONS,
-      textColumns,
+      isCollapsed, toggleCollapsed, textBkColor, enableTextScrollCursor,
+      textScrollCursorBlinkSpeed, BLINK_SPEED_OPTIONS, textMaxDisplayWidth,
+      TEXT_MAX_DISPLAY_WIDTH_OPTIONS, TEXT_CARD_MAX_LENGTH, textColumns,
       dragAttrs, dragCardClass, dragHandleListeners, dragTargetListeners,
     };
   },
@@ -438,6 +509,17 @@ export default defineComponent({
   padding-right: 0;
 }
 
+/* Pulls this intro paragraph up 5px - confirmed directly (measured from the
+   "Text" title's own text glyphs down to this paragraph's own top: 20px,
+   vs. only 15px between the Text Minikernel Font subcard's own header and
+   ITS description right below it - TextFontEditor.vue's own custom header
+   has less bottom padding than Vuetify's default v-card-title). Matches
+   that tighter subcard spacing instead of the wider gap Vuetify's own
+   v-card-title default padding otherwise leaves here. */
+.text-intro-paragraph {
+  margin-top: -5px;
+}
+
 .text-bkcolor-row {
   display: flex;
   align-items: center;
@@ -445,15 +527,41 @@ export default defineComponent({
   margin-bottom: 16px;
 }
 
+/* Same margin-top/padding-top override as .text-columns-switch below -
+   Vuetify's own selection-control margin-top (meant for stacking below
+   other fields) otherwise leaves extra space above this switch. Sits inline
+   in .text-bkcolor-row now, to the right of the color picker, so no
+   margin-bottom is needed either. */
+.text-scroll-cursor-switch {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+  margin-bottom: 0;
+  margin-left: 16px;
+}
+
 /* Matches the Score tab's own .score-bkcolor-label size (ScoreFontEditor.vue). */
 .text-bkcolor-label {
   font-size: 1rem;
+}
+
+/* Vuetify's own v-select reserves space above the input for its label,
+   sitting lower than .text-scroll-cursor-switch's own centered toggle+label
+   row right next to it - nudged up to bring its own input line back onto
+   the same baseline. */
+.text-blink-speed-field {
+  max-width: 160px;
+  margin-top: -6px;
+  margin-left: 16px;
 }
 
 .text-max-width-row {
   display: flex;
   align-items: center;
   gap: 16px;
+}
+
+.text-max-width-help {
+  margin-top: 8px;
 }
 
 .text-max-width-field {


### PR DESCRIPTION
## Summary
- Add a scroll cursor (up/down arrows plus an end-of-message icon) for the Text Minikernel, with independently settable colors, a blink-speed control (including a "Never" option), and lookup-table-based rendering to keep the added cycles low.
- Add row 2 text color, automatically falling back to row 1's color until explicitly set.
- Add a score padding option (0-2 extra background scanlines drawn right after the score digits).
- Fix auto word-wrap to produce as many lines as a message needs instead of capping at 2.
- Fix a scrambled row 2 text bug caused by a clobbered accumulator.
- Fix the Text Font Editor's in-game preview/label layout for the cursor shape.
- Rename "Wrap to line 2" to "Multiline" and add a 240-character hard cap per text card.
- Fix Save/Save As/Open Project silently doing nothing when the app is embedded in a cross-origin iframe: Chrome unconditionally throws a SecurityError for `showSaveFilePicker`/`showOpenFilePicker` there, with no way to opt back in, so this now falls back to the same download/file-input path already used on browsers without the File System Access API.

## Test plan
- [ ] Build and load a project with Text Minikernel scroll cursor enabled; verify up/down arrows and end-of-message icon render correctly with independent colors and blink speed.
- [ ] Verify row 2 text color falls back to row 1's color until explicitly overridden.
- [ ] Verify score padding dropdown (0/1/2) renders the expected extra background scanlines.
- [ ] Verify a 3+ line text message wraps to all needed lines, not just 2.
- [ ] Verify Save/Save As/Open Project work when the app is embedded in a cross-origin iframe (falls back to file download/native file input).